### PR TITLE
New page for calendar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ edweiss-app/package-lock.json
 .vscode/settings.json
 .vscode/settings.json
 .vscode/settings.json
+edweiss-app/package-lock.json
+.vscode/settings.json
+edweiss-app/package.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/settings.json
+.vscode/settings.json
+edweiss-app/package.json
+edweiss-app/package-lock.json
+edweiss-app/package-lock.json
+edweiss-app/app.config.ts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ edweiss-app/package.json
 edweiss-app/package-lock.json
 edweiss-app/package-lock.json
 edweiss-app/app.config.ts
+edweiss-app/package-lock.json
+edweiss-app/package-lock.json
+.vscode/settings.json
+.vscode/settings.json
+.vscode/settings.json

--- a/edweiss-app/__test__/home_page/Day.test.tsx
+++ b/edweiss-app/__test__/home_page/Day.test.tsx
@@ -1,8 +1,13 @@
+import { callFunction } from '@/config/firebase';
 import { Course, CourseTimePeriod } from '@/model/school/courses';
 import { fireEvent, render } from '@testing-library/react-native';
 import { router } from 'expo-router';
 import React from 'react';
 import { Day } from '../../components/core/Day';
+
+jest.mock('@/config/firebase', () => ({
+    callFunction: jest.fn(),
+}));
 
 jest.mock('expo-router', () => ({
     router: {
@@ -52,8 +57,7 @@ describe('Day Component', () => {
                 course={{ id: 'course1', data: mockCourse }}
                 user={mockUserProfessor}
                 filteredPeriods={[mockPeriod]}
-                index={0}
-            />
+                index={0} format={"day"} />
         );
 
         expect(getByText('Test Course')).toBeTruthy();
@@ -78,8 +82,7 @@ describe('Day Component', () => {
                 course={{ id: 'course1', data: mockCourse }}
                 user={mockUserStudent}
                 filteredPeriods={[mockPeriod]}
-                index={0}
-            />
+                index={0} format={"week"} />
         );
 
         expect(getByText('Test Course')).toBeTruthy();
@@ -106,9 +109,12 @@ describe('Day Component', () => {
                 course={{ id: 'course1', data: mockCourse }}
                 user={mockUserProfessor}
                 filteredPeriods={[periodWithoutEnd]}
-                index={0}
-            />
+                index={0} format={"day"} />
         );
         expect(getByText('Test Course')).toBeTruthy();
+        (callFunction as jest.Mock).mockRejectedValueOnce(new Error("Erreur de test"));
+
+
+
     });
 });

--- a/edweiss-app/__test__/home_page/Day.test.tsx
+++ b/edweiss-app/__test__/home_page/Day.test.tsx
@@ -49,16 +49,23 @@ const mockUserStudent = {
     },
 };
 
+function renderDayComponent({ user, period, format }: { user: any, period: CourseTimePeriod, format: string; }) {
+    return render(
+        <Day
+            course={{ id: 'course1', data: mockCourse }}
+            user={user}
+            filteredPeriods={[period]}
+            index={0}
+            format={format} period={period} />
+    );
+}
+
+
+const { getByText } = renderDayComponent({ user: mockUserProfessor, period: mockPeriod, format: "day" });
+
 describe('Day Component', () => {
     it('renders correctly for a professor and navigates on press', () => {
-        const { getByText } = render(
-            <Day
-                period={mockPeriod}
-                course={{ id: 'course1', data: mockCourse }}
-                user={mockUserProfessor}
-                filteredPeriods={[mockPeriod]}
-                index={0} format={"day"} />
-        );
+        const { getByText } = renderDayComponent({ user: mockUserProfessor, period: mockPeriod, format: "day" });
 
         expect(getByText('Test Course')).toBeTruthy();
 
@@ -76,14 +83,7 @@ describe('Day Component', () => {
     });
 
     it('renders correctly for a student and navigates on press', () => {
-        const { getByText } = render(
-            <Day
-                period={mockPeriod}
-                course={{ id: 'course1', data: mockCourse }}
-                user={mockUserStudent}
-                filteredPeriods={[mockPeriod]}
-                index={0} format={"week"} />
-        );
+        const { getByText } = renderDayComponent({ user: mockUserStudent, period: mockPeriod, format: "week" });
 
         expect(getByText('Test Course')).toBeTruthy();
 
@@ -101,20 +101,9 @@ describe('Day Component', () => {
     });
 
     it('handles the case when period does not have an end time', () => {
-        const periodWithoutEnd = { ...mockPeriod, end: mockPeriod.end ?? 0 };
 
-        const { getByText } = render(
-            <Day
-                period={periodWithoutEnd}
-                course={{ id: 'course1', data: mockCourse }}
-                user={mockUserProfessor}
-                filteredPeriods={[periodWithoutEnd]}
-                index={0} format={"day"} />
-        );
+        const { getByText } = renderDayComponent({ user: mockUserProfessor, period: mockPeriod, format: "day" });
         expect(getByText('Test Course')).toBeTruthy();
         (callFunction as jest.Mock).mockRejectedValueOnce(new Error("Erreur de test"));
-
-
-
     });
 });

--- a/edweiss-app/__test__/home_page/my_Calendar.test.tsx
+++ b/edweiss-app/__test__/home_page/my_Calendar.test.tsx
@@ -6,10 +6,13 @@ import React from 'react';
 
 
 
+jest.mock('@/components/core/calendar', () => ({
+    Calendar: jest.fn(() => <div>Mocked Calendar</div>),
+}));
+
 jest.mock('@/components/core/header/RouteHeader', () => () => {
     return <div>Mocked RouteHeader</div>;
 });
-
 const mockCourses = [
     {
         id: 'course1',
@@ -116,13 +119,12 @@ describe('my_Calendar', () => {
         (useAuth as jest.Mock).mockReturnValue({ authUser: mockUser });
 
         render(<MyCalendar />);
-
         expect(useAuth).toHaveBeenCalled();
         expect(useAuth().authUser).toEqual(mockUser);
     });
 
     it('should fetch user courses correctly', () => {
-        const mockUser = { uid: 'user-123' };
+        const mockUser = { uid: 'tPpkVzKlNhRbANSMdcit1cuPLYr1' };
         (useAuth as jest.Mock).mockReturnValue({ authUser: mockUser });
 
         (useDynamicDocs as jest.Mock)
@@ -139,5 +141,7 @@ describe('my_Calendar', () => {
         expect(useDynamicDocs).toHaveBeenCalledWith(
             expect.anything()
         );
+
+
     });
 });

--- a/edweiss-app/__test__/home_page/my_Calendar.test.tsx
+++ b/edweiss-app/__test__/home_page/my_Calendar.test.tsx
@@ -1,0 +1,143 @@
+import MyCalendar from '@/app/(app)/my_Calendar';
+import { useAuth } from '@/contexts/auth';
+import { useDynamicDocs } from '@/hooks/firebase/firestore';
+import { render } from '@testing-library/react-native';
+import React from 'react';
+
+
+
+jest.mock('@/components/core/header/RouteHeader', () => () => {
+    return <div>Mocked RouteHeader</div>;
+});
+
+const mockCourses = [
+    {
+        id: 'course1',
+        data: {
+            periods: [
+                {
+                    id: 'period1',
+                    start: 480,
+                    end: 500,
+                    dayIndex: 1,
+                },
+                {
+                    id: 'period2',
+                    start: 540,
+                    dayIndex: 1,
+                },
+            ],
+            name: 'Course 1',
+            credits: 3,
+        },
+    },
+    {
+        id: 'course2',
+        data: {
+            periods: [
+                {
+                    id: 'period3',
+                    start: 600,
+                    dayIndex: 1,
+                },
+            ],
+            name: 'Course 2',
+            credits: 4,
+        },
+    },
+];
+
+
+jest.mock('@/contexts/auth', () => ({
+    useAuth: jest.fn(),
+}));
+jest.mock('@/hooks/firebase/firestore', () => ({
+    useDynamicDocs: jest.fn(),
+}));
+jest.mock('@react-native-firebase/auth', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        currentUser: { uid: 'test-user-id' },
+    })),
+}));
+jest.mock('@react-native-firebase/firestore', () => {
+    const collectionMock = {
+        doc: jest.fn().mockReturnThis(),
+        get: jest.fn().mockResolvedValue({
+            id: 'course1',
+            data: jest.fn(() => mockCourses.map((course) => course.data)),
+        }),
+    };
+    return {
+        __esModule: true,
+        default: jest.fn(() => ({
+            collection: jest.fn(() => collectionMock),
+        })),
+        FirebaseFirestoreTypes: {
+            DocumentReference: jest.fn(),
+        },
+    };
+});
+
+jest.mock('@react-native-firebase/functions', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        httpsCallable: jest.fn(),
+    })),
+}));
+
+
+jest.mock('@react-native-firebase/storage', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        ref: jest.fn(),
+    })),
+}));
+
+jest.mock('@react-native-google-signin/google-signin', () => ({
+    __esModule: true,
+    GoogleSignin: {
+        configure: jest.fn(),
+        hasPlayServices: jest.fn(),
+        signIn: jest.fn(),
+        signOut: jest.fn(),
+        isSignedIn: jest.fn(),
+        getCurrentUser: jest.fn(),
+    },
+}));
+
+describe('my_Calendar', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should import the authenticated user correctly', () => {
+        const mockUser = { uid: 'user-123' };
+        (useAuth as jest.Mock).mockReturnValue({ authUser: mockUser });
+
+        render(<MyCalendar />);
+
+        expect(useAuth).toHaveBeenCalled();
+        expect(useAuth().authUser).toEqual(mockUser);
+    });
+
+    it('should fetch user courses correctly', () => {
+        const mockUser = { uid: 'user-123' };
+        (useAuth as jest.Mock).mockReturnValue({ authUser: mockUser });
+
+        (useDynamicDocs as jest.Mock)
+            .mockReturnValueOnce([
+                { id: 'course-1', data: {} },
+                { id: 'course-2', data: {} },
+            ])
+            .mockReturnValueOnce([
+                { id: 'course-1', data: {} },
+                { id: 'course-3', data: {} },
+            ]);
+        render(<MyCalendar />);
+
+        expect(useDynamicDocs).toHaveBeenCalledWith(
+            expect.anything()
+        );
+    });
+});

--- a/edweiss-app/__test__/home_page/startCourseScreen.test.tsx
+++ b/edweiss-app/__test__/home_page/startCourseScreen.test.tsx
@@ -1,0 +1,108 @@
+import StartCourseScreen from '@/app/(app)/startCourseScreen';
+import { callFunction } from '@/config/firebase';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { useLocalSearchParams } from 'expo-router';
+import React from 'react';
+
+jest.mock('expo-router', () => ({
+    useLocalSearchParams: jest.fn(),
+    router: {
+        push: jest.fn(),
+    },
+}));
+
+jest.mock('@/config/firebase', () => ({
+    callFunction: jest.fn(),
+}));
+
+jest.mock('@/components/core/header/RouteHeader', () => () => {
+    return <div>Mocked RouteHeader</div>;
+});
+
+const mockCourse = JSON.stringify({
+    name: "Course Test",
+    started: false,
+});
+
+const mockPeriod = JSON.stringify({
+    activityId: "1234",
+});
+
+(useLocalSearchParams as jest.Mock).mockReturnValue({
+    courseID: 'testCourseID',
+    course: mockCourse,
+    period: mockPeriod,
+    index: 0,
+});
+
+describe('StartCourseScreen', () => {
+
+    beforeAll(() => {
+        console.error = jest.fn();
+    });
+
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should render all buttons', () => {
+        render(<StartCourseScreen />);
+
+        expect(screen.getByText("Start course")).toBeTruthy();
+        expect(screen.getByText("Show to student")).toBeTruthy();
+        expect(screen.getByText("Go to show Time")).toBeTruthy();
+        expect(screen.getByText("Go to STRC")).toBeTruthy();
+        expect(screen.getByText("Send my Token")).toBeTruthy();
+    });
+
+    it('should toggle course start/stop on button press', async () => {
+        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1 });
+
+        const { rerender } = render(<StartCourseScreen />);
+        const startButton = screen.getByText("Start course");
+
+        await act(async () => {
+            fireEvent.press(startButton);
+        });
+
+        rerender(<StartCourseScreen />);
+        expect(screen.getByText("Stop course")).toBeTruthy();
+    });
+
+    it('starts the course and shows "Stop course" after clicking "Start course"', async () => {
+        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1 });
+        render(<StartCourseScreen />);
+        const startButton = screen.getByText("Start course").parent;
+        expect(startButton).toBeTruthy();
+        if (startButton) fireEvent.press(startButton);
+
+        await waitFor(() => expect(screen.getByText("Stop course")).toBeTruthy());
+        expect(callFunction).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ courseID: expect.any(String) }));
+    });
+
+    it('displays an error if toogle_2 fails', async () => {
+        (callFunction as jest.Mock).mockRejectedValueOnce(new Error("Test error"));
+        render(<StartCourseScreen />);
+        const showButton = screen.getByText("Show to student").parent;
+        if (showButton) {
+            fireEvent.press(showButton);
+        }
+        await waitFor(() => expect(console.error).toHaveBeenCalledWith("Error toggling period:", expect.any(Error)));
+    });
+
+    it('updates availability when the toogle_2 function is executed successfully', async () => {
+        (callFunction as jest.Mock).mockResolvedValueOnce({
+            status: 1,
+            data: { available: true },
+        });
+
+        render(<StartCourseScreen />);
+
+        const showButton = screen.getByText("Show to student").parent;
+
+        if (showButton) {
+            fireEvent.press(showButton);
+            await waitFor(() => expect(screen.getByText("Sharing in progress...")).toBeTruthy());
+        }
+    });
+});

--- a/edweiss-app/app.config.ts
+++ b/edweiss-app/app.config.ts
@@ -5,7 +5,6 @@ const config: ExpoConfig = {
 	"name": "EdWeiss",
 	"slug": "edweiss",
 	"version": "1.0.0",
-	"orientation": "portrait",
 	"icon": "./assets/images/icon.png",
 	"scheme": "edweiss",
 	"userInterfaceStyle": "automatic",

--- a/edweiss-app/app/(app)/(tabs)/index.tsx
+++ b/edweiss-app/app/(app)/(tabs)/index.tsx
@@ -14,9 +14,6 @@ import { Course } from '@/model/school/courses';
 import { router } from 'expo-router';
 import React from 'react';
 
-
-
-
 const HomeTab = () => {
 	const auth = useAuth();
 	const courses = useDynamicDocs(CollectionOf<Course>("courses"))?.map(doc => ({
@@ -33,10 +30,14 @@ const HomeTab = () => {
 	const myCourseIds = my_courses.map(course => course.id);
 	const filteredCourses = courses.filter(course => myCourseIds.includes(course.id));
 
-
 	return (
 		<TView flex={1} p={16} backgroundColor='base'>
-			<Calendar courses={filteredCourses} />
+			<TTouchableOpacity radius={10} p={5}
+				style={{ marginVertical: 8, width: '100%', borderRadius: 10, borderWidth: 2, borderColor: 'pink' }}
+				onPress={() => router.push("/(app)/my_Calendar")}>
+				<TText align='center'>My Calendar</TText>
+			</TTouchableOpacity>
+			<Calendar courses={filteredCourses} type={'day'} />
 			<TScrollView flex={1} horizontal={false} showsVerticalScrollIndicator={true}>
 				<TText align='center'>List of courses</TText>
 				<For each={filteredCourses} key="id">

--- a/edweiss-app/app/(app)/my_Calendar/index.tsx
+++ b/edweiss-app/app/(app)/my_Calendar/index.tsx
@@ -1,4 +1,5 @@
 
+import { Calendar } from '@/components/core/calendar';
 import TView from '@/components/core/containers/TView';
 import RouteHeader from '@/components/core/header/RouteHeader';
 import { CollectionOf } from '@/config/firebase';
@@ -6,7 +7,6 @@ import { useAuth } from '@/contexts/auth';
 import { useDynamicDocs } from '@/hooks/firebase/firestore';
 import { Course } from '@/model/school/courses';
 import React from 'react';
-import { Calendar } from 'react-native-calendars';
 
 export const MyCalendar = () => {
 

--- a/edweiss-app/app/(app)/my_Calendar/index.tsx
+++ b/edweiss-app/app/(app)/my_Calendar/index.tsx
@@ -1,0 +1,36 @@
+
+import TView from '@/components/core/containers/TView';
+import RouteHeader from '@/components/core/header/RouteHeader';
+import { CollectionOf } from '@/config/firebase';
+import { useAuth } from '@/contexts/auth';
+import { useDynamicDocs } from '@/hooks/firebase/firestore';
+import { Course } from '@/model/school/courses';
+import React from 'react';
+import { Calendar } from 'react-native-calendars';
+
+export const MyCalendar = () => {
+
+  const auth = useAuth();
+  const courses = useDynamicDocs(CollectionOf<Course>("courses"))?.map(doc => ({
+    id: doc.id,
+    data: doc.data
+  })) ?? [];
+  const my_courses = useDynamicDocs(
+    CollectionOf<Course>("users/" + (auth.authUser?.uid ?? 'default-uid') + "/courses")
+  )?.map(doc => ({
+    id: doc.id,
+    data: doc.data
+  })) ?? [];
+
+  const myCourseIds = my_courses.map(course => course.id);
+  const filteredCourses = courses.filter(course => myCourseIds.includes(course.id));
+
+  return (
+    <><RouteHeader disabled />
+      <TView flex={1} p={16} backgroundColor='base'>
+        <Calendar courses={filteredCourses} type={undefined} />
+      </TView>
+    </>
+  );
+};
+export default MyCalendar;

--- a/edweiss-app/app/(app)/my_Calendar/index.tsx
+++ b/edweiss-app/app/(app)/my_Calendar/index.tsx
@@ -7,7 +7,7 @@ import { useDynamicDocs } from '@/hooks/firebase/firestore';
 import { Course } from '@/model/school/courses';
 import React from 'react';
 
-const fetchCourses = (collectionPath: string) => {
+const useFetchCourses = (collectionPath: string) => {
   return useDynamicDocs(CollectionOf<Course>(collectionPath))?.map(doc => ({
     id: doc.id,
     data: doc.data
@@ -16,8 +16,8 @@ const fetchCourses = (collectionPath: string) => {
 
 export const MyCalendar = () => {
   const auth = useAuth();
-  const courses = fetchCourses("courses");
-  const my_courses = fetchCourses("users/" + (auth.authUser?.uid ?? 'default-uid') + "/courses");
+  const courses = useFetchCourses("courses");
+  const my_courses = useFetchCourses("users/" + (auth.authUser?.uid ?? 'default-uid') + "/courses");
 
   const myCourseIds = my_courses.map(course => course.id);
   const filteredCourses = courses.filter(course => myCourseIds.includes(course.id));

--- a/edweiss-app/app/(app)/my_Calendar/index.tsx
+++ b/edweiss-app/app/(app)/my_Calendar/index.tsx
@@ -1,4 +1,3 @@
-
 import { Calendar } from '@/components/core/calendar';
 import TView from '@/components/core/containers/TView';
 import RouteHeader from '@/components/core/header/RouteHeader';
@@ -8,29 +7,29 @@ import { useDynamicDocs } from '@/hooks/firebase/firestore';
 import { Course } from '@/model/school/courses';
 import React from 'react';
 
-export const MyCalendar = () => {
+const fetchCourses = (collectionPath: string) => {
+  return useDynamicDocs(CollectionOf<Course>(collectionPath))?.map(doc => ({
+    id: doc.id,
+    data: doc.data
+  })) ?? [];
+};
 
+export const MyCalendar = () => {
   const auth = useAuth();
-  const courses = useDynamicDocs(CollectionOf<Course>("courses"))?.map(doc => ({
-    id: doc.id,
-    data: doc.data
-  })) ?? [];
-  const my_courses = useDynamicDocs(
-    CollectionOf<Course>("users/" + (auth.authUser?.uid ?? 'default-uid') + "/courses")
-  )?.map(doc => ({
-    id: doc.id,
-    data: doc.data
-  })) ?? [];
+  const courses = fetchCourses("courses");
+  const my_courses = fetchCourses("users/" + (auth.authUser?.uid ?? 'default-uid') + "/courses");
 
   const myCourseIds = my_courses.map(course => course.id);
   const filteredCourses = courses.filter(course => myCourseIds.includes(course.id));
 
   return (
-    <><RouteHeader disabled />
+    <>
+      <RouteHeader disabled />
       <TView flex={1} p={16} backgroundColor='base'>
         <Calendar courses={filteredCourses} type={undefined} />
       </TView>
     </>
   );
 };
+
 export default MyCalendar;

--- a/edweiss-app/app/(app)/startCourseScreen/index.tsx
+++ b/edweiss-app/app/(app)/startCourseScreen/index.tsx
@@ -2,18 +2,16 @@ import TView from '@/components/core/containers/TView';
 import RouteHeader from '@/components/core/header/RouteHeader';
 import TText from '@/components/core/TText';
 import FancyButton from '@/components/input/FancyButton';
-import { callFunction, Collection } from '@/config/firebase';
+import { callFunction } from '@/config/firebase';
 import { Color } from '@/constants/Colors';
 import { ApplicationRoute } from '@/constants/Component';
-import LectureDisplay from '@/model/lectures/lectureDoc';
 import { Course, Course_functions, CourseTimePeriod } from '@/model/school/courses';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { ActivityIndicator } from 'react-native';
 
-type Lecture = LectureDisplay.Lecture;
 
-const StartCourseScreen: ApplicationRoute = () => {
+export const StartCourseScreen: ApplicationRoute = () => {
 	const { courseID, course, period } = useLocalSearchParams() as unknown as { courseID: string; course: string; period: string; index: number; };
 	const [loading, setLoading] = useState(false);
 	const [parsedCourse, setParsedCourse] = useState<Course>(JSON.parse(course));

--- a/edweiss-app/components/core/Day.tsx
+++ b/edweiss-app/components/core/Day.tsx
@@ -5,10 +5,9 @@ import TTouchableOpacity from './containers/TTouchableOpacity';
 import { PeriodBlock } from './PeriodBlock';
 
 const HOUR_BLOCK_HEIGHT = 80;
-const TOTAL_HOURS = 24;
 
-export const Day = ({ period, course, user, filteredPeriods, index }: {
-    period: CourseTimePeriod; course: { id: string; data: Course; }; user: any; filteredPeriods: any[]; index: number;
+export const Day = ({ period, course, user, filteredPeriods, index, format }: {
+    period: CourseTimePeriod; course: { id: string; data: Course; }; user: any; filteredPeriods: any[]; index: number; format: string;
 }) => {
     const periodHeight = period.end ? ((period.end - period.start) / 60) * HOUR_BLOCK_HEIGHT : HOUR_BLOCK_HEIGHT;
 
@@ -42,10 +41,10 @@ export const Day = ({ period, course, user, filteredPeriods, index }: {
             }}
             backgroundColor={courseColors[period.type as keyof typeof courseColors] as Color || 'base'}
             style={{
-                height: periodHeight
+                height: periodHeight,
             }}
         >
-            <PeriodBlock period={period} course={course} user={user} />
+            <PeriodBlock period={period} format={format} course={course} user={user} />
         </TTouchableOpacity>
     );
 };

--- a/edweiss-app/components/core/Day.tsx
+++ b/edweiss-app/components/core/Day.tsx
@@ -19,7 +19,7 @@ export const Day = ({ period, course, user, filteredPeriods, index, format }: {
             borderColor="overlay2"
             radius={10}
             b={2}
-            p={2}
+
             onPress={() => {
                 {
                     user.data.type == 'professor' && router.push({

--- a/edweiss-app/components/core/Day.tsx
+++ b/edweiss-app/components/core/Day.tsx
@@ -10,7 +10,13 @@ export const Day = ({ period, course, user, filteredPeriods, index, format }: {
     period: CourseTimePeriod; course: { id: string; data: Course; }; user: any; filteredPeriods: any[]; index: number; format: string;
 }) => {
     const periodHeight = period.end ? ((period.end - period.start) / 60) * HOUR_BLOCK_HEIGHT : HOUR_BLOCK_HEIGHT;
-
+    const pathname = user.data.type == 'professor' ? '/(app)/startCourseScreen' : '/(app)/lectures/slides';
+    const params = user.data.type == 'professor' ? {
+        courseID: course.id, course: JSON.stringify(course.data), period: JSON.stringify(period), index,
+    } : {
+        courseNameString: course.data.name,
+        lectureIdString: period.activityId
+    };
     return (
 
         <TTouchableOpacity
@@ -22,22 +28,11 @@ export const Day = ({ period, course, user, filteredPeriods, index, format }: {
 
             onPress={() => {
                 {
-                    user.data.type == 'professor' && router.push({
-                        pathname: '/(app)/startCourseScreen',
-                        params: {
-                            courseID: course.id, course: JSON.stringify(course.data), period: JSON.stringify(period), index,
-                        }
+                    router.push({
+                        pathname: pathname,
+                        params: params
                     });
                 }
-                {
-                    user.data.type == 'student' && course.data.started && period.type == 'lecture' && router.push({
-                        pathname: '/(app)/lectures/slides' as any,
-                        params: {
-                            courseNameString: course.data.name,
-                            lectureIdString: period.activityId
-                        }
-                    });
-                };
             }}
             backgroundColor={courseColors[period.type as keyof typeof courseColors] as Color || 'base'}
             style={{

--- a/edweiss-app/components/core/PeriodBlock.tsx
+++ b/edweiss-app/components/core/PeriodBlock.tsx
@@ -3,29 +3,32 @@ import TView from './containers/TView';
 import formatTime from './formatTime';
 import TText from './TText';
 
-export const PeriodBlock = ({ period, course, user }: {
-    period: CourseTimePeriod; course: { id: string; data: Course; }; user: any;
+export const PeriodBlock = ({ period, course, user, format }: {
+    period: CourseTimePeriod; course: { id: string; data: Course; }; user: any; format: String;
 }) => {
+    const direction = format == 'week' ? 'column' : 'row';
+    const size1 = format == 'week' ? 12 : 15;
+    const size2 = format == 'week' ? 9 : 12;
     return (
         <TView flexDirection="column">
-            <TView flexDirection="row" justifyContent="space-between">
-                <TText color="course_title_for_backgroud_color" numberOfLines={1} size={15} p={5}>
+            <TView justifyContent="space-between" flexDirection={direction}>
+                <TText color="course_title_for_backgroud_color" numberOfLines={1} size={size1} p={5}>
                     {`${period.type.charAt(0).toUpperCase() + period.type.slice(1)}`}
                 </TText>
-                <TText pr={10} pt={7} color="overlay2" numberOfLines={1} size={12}>
+                <TText pl={5} pr={10} pt={7} color="overlay2" numberOfLines={1} size={size2}>
                     {`${period.rooms.join(", ")}`}
                 </TText>
             </TView>
-            <TText pl={5} color="overlay2" numberOfLines={1} size={12}>
+            <TText pl={5} pb={5} pt={3} color="overlay0" numberOfLines={1} size={size2}>
                 {`${course.data.name}`}
             </TText>
-            <TView flexDirection="row">
-                <TText p={5} size={12} color="overlay2">
+            <TView flexDirection={direction}>
+                <TText p={3} size={size2} color="overlay2">
                     {`${formatTime(period.start)} - ${formatTime(period.end)}`}
                 </TText>
             </TView>
             {user.data.type == 'student' && course.data.started && period.type == 'lecture' && <TText p={5} size={15} color="red">Join Course</TText>}
             {user.data.type == 'professor' && period.type == 'lecture' && <TText p={5} size={15} color={course.data.started ? "red" : "green"}>{(!course.data.started && "Start Course") || (course.data.started && "Stop Course")}</TText>}
-        </TView>
+        </TView >
     );
 };

--- a/edweiss-app/components/core/PeriodBlock.tsx
+++ b/edweiss-app/components/core/PeriodBlock.tsx
@@ -4,7 +4,7 @@ import formatTime from './formatTime';
 import TText from './TText';
 
 export const PeriodBlock = ({ period, course, user, format }: {
-    period: CourseTimePeriod; course: { id: string; data: Course; }; user: any; format: String;
+    period: CourseTimePeriod; course: { id: string; data: Course; }; user: any; format: string;
 }) => {
     const direction = format == 'week' ? 'column' : 'row';
     const size1 = format == 'week' ? 12 : 15;

--- a/edweiss-app/components/core/calendar.tsx
+++ b/edweiss-app/components/core/calendar.tsx
@@ -67,11 +67,11 @@ export const Calendar = ({ courses, type }: { courses: { id: string; data: Cours
     const renderDay = (dayIndex: number) => (
         <TView key={dayIndex} flex={1} >
             {Array.from({ length: TOTAL_HOURS }).map((_, hour) => (
-                <TView key={hour} bb={1} bl={1} borderColor='pink' style={{
+                <TView bb={1} bl={1} borderColor='pink' style={{
                     height: HOUR_BLOCK_HEIGHT,
                 }} flexDirection="row">
                     <TView flexDirection="row" flex={1} >
-                        <For each={courses} key="id">
+                        <For each={courses}>
                             {course =>
                                 course.data.periods
                                     .filter(
@@ -79,7 +79,6 @@ export const Calendar = ({ courses, type }: { courses: { id: string; data: Cours
                                     )
                                     .map((period, index, filteredPeriods) => (
                                         <Day
-                                            key={index}
                                             period={period}
                                             course={course}
                                             user={user}
@@ -136,7 +135,7 @@ export const Calendar = ({ courses, type }: { courses: { id: string; data: Cours
                 <TView flexDirection="row">
                     <TView style={(format == 'week' && { width: '7%' }) || (format == 'day' && { width: '14%' })}>
                         {Array.from({ length: TOTAL_HOURS }).map((_, hour) => (
-                            <TView key={hour} alignItems='center' justifyContent='center' bt={1} bb={1} borderColor='yellow' style={{ height: HOUR_BLOCK_HEIGHT }}>
+                            <TView alignItems='center' justifyContent='center' bt={1} bb={1} borderColor='yellow' style={{ height: HOUR_BLOCK_HEIGHT }}>
                                 <TText color='text' size={12}>{`${hour}:00`}</TText>
                             </TView>
                         ))}

--- a/edweiss-app/components/core/calendar.tsx
+++ b/edweiss-app/components/core/calendar.tsx
@@ -1,13 +1,13 @@
 import { Collections, getDocument } from '@/config/firebase';
 import { useAuth } from '@/contexts/auth';
 import { Course } from '@/model/school/courses';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import React, { useEffect, useRef, useState } from 'react';
 import { ScrollView } from 'react-native-gesture-handler';
 import TTouchableOpacity from './containers/TTouchableOpacity';
 import TView from './containers/TView';
-import For from './For';
-
 import { Day } from './Day';
+import For from './For';
 import { getCurrentDay } from './getCurrentDay';
 import { getCurrentTimeInMinutes } from './getCurrentTimeInMinutes';
 import TText from './TText';
@@ -15,13 +15,37 @@ import TText from './TText';
 const HOUR_BLOCK_HEIGHT = 80;
 const TOTAL_HOURS = 24;
 
+const DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+const DAY_ORDER = [1, 2, 3, 4, 5, 6, 0];
 
+export const Calendar = ({ courses, type }: { courses: { id: string; data: Course; }[]; type: "week" | "day" | undefined; }) => {
 
-export const Calendar = ({ courses }: { courses: { id: string; data: Course; }[]; }) => {
     const [currentMinutes, setCurrentMinutes] = useState(getCurrentTimeInMinutes());
     const scrollViewRef = useRef<ScrollView>(null);
     const [user, setUser] = useState<any>(null);
     const userId = useAuth().uid;
+
+    const [format, setFormat] = useState(type);
+    useEffect(() => {
+        if (type === undefined) {
+            setFormat("day");
+        }
+    }, [type]);
+    useEffect(() => {
+        const onOrientationChange = (currentOrientation: ScreenOrientation.OrientationChangeEvent) => {
+            const orientationValue = currentOrientation.orientationInfo.orientation;
+            if (type === undefined) {
+                if (orientationValue == 1 || orientationValue == 2) setFormat("day");
+                else setFormat("week");
+            }
+        };
+        const screenOrientationListener =
+            ScreenOrientation.addOrientationChangeListener(onOrientationChange);
+
+        return () => {
+            ScreenOrientation.removeOrientationChangeListener(screenOrientationListener);
+        };
+    }, []);
 
     useEffect(() => {
         const fetchUser = async () => {
@@ -30,6 +54,7 @@ export const Calendar = ({ courses }: { courses: { id: string; data: Course; }[]
         };
         fetchUser();
     }, [userId]);
+
     useEffect(() => {
         const interval = setInterval(() => { setCurrentMinutes(getCurrentTimeInMinutes()); }, 60000);
         return () => clearInterval(interval);
@@ -39,67 +64,92 @@ export const Calendar = ({ courses }: { courses: { id: string; data: Course; }[]
         scrollViewRef.current?.scrollTo({ y: (currentMinutes / 60 - 1) * HOUR_BLOCK_HEIGHT, animated: true });
     }, []);
 
+    const renderDay = (dayIndex: number) => (
+        <TView key={dayIndex} flex={1} >
+            {Array.from({ length: TOTAL_HOURS }).map((_, hour) => (
+                <TView key={hour} bb={1} bl={1} borderColor='pink' p={10} style={{
+                    height: HOUR_BLOCK_HEIGHT,
+                }} flexDirection="row">
+                    <TView flexDirection="row" flex={1}>
+                        <For each={courses} key="id">
+                            {course =>
+                                course.data.periods
+                                    .filter(
+                                        period => period.start >= hour * 60 && period.start < (hour + 1) * 60 && period.dayIndex === dayIndex
+                                    )
+                                    .map((period, index, filteredPeriods) => (
+                                        <Day
+                                            key={index}
+                                            period={period}
+                                            course={course}
+                                            user={user}
+                                            filteredPeriods={filteredPeriods}
+                                            index={index}
+                                            format={format || "day"}
+                                        />
+                                    ))
+                            }
+                        </For>
+                    </TView>
+                </TView>
+            ))}
+
+            {dayIndex === getCurrentDay() && (
+                <TView
+                    backgroundColor='red'
+                    style={{
+                        position: 'absolute',
+                        width: '100%',
+                        height: 2,
+                        top: (currentMinutes / 60) * HOUR_BLOCK_HEIGHT,
+                    }}
+                />
+            )}
+        </TView>
+    );
+
     return (
         <TView mb={16} flex={1} key={userId}>
-            <TText align='center'>My Calendar</TText>
-            <TTouchableOpacity borderColor='yellow' b={2} radius={10} p={5}
-                style={{ marginVertical: 8, width: '100%', borderRadius: 10, borderWidth: 2 }}
-                onPress={() => scrollViewRef.current?.scrollTo({ y: (currentMinutes / 60 - 0.8) * HOUR_BLOCK_HEIGHT, animated: true })}
-            >
-                <TText color='yellow' align='center'>now</TText>
-            </TTouchableOpacity>
+            {format === "day" && (
+                <TTouchableOpacity radius={10} p={5}
+                    style={{ marginVertical: 8, width: '100%', borderRadius: 10, borderWidth: 2, borderColor: 'pink' }}
+                    onPress={() => scrollViewRef.current?.scrollTo({ y: (currentMinutes / 60 - 0.8) * HOUR_BLOCK_HEIGHT, animated: true })}
+                >
+                    <TText color='pink' align='center'>now</TText>
+                </TTouchableOpacity>
+            )}
+
+            {format === "week" && (
+                <TView flexDirection="row" >
+                    <TText align='center' style={{ width: '7%' }} >Time</TText>
+                    {DAY_NAMES.map((dayName, index) => (
+                        <TText key={index} align='center' style={{ width: '13.3%' }}>
+                            {dayName}
+                        </TText>
+                    ))}
+                </TView>
+            )}
             <ScrollView
                 ref={scrollViewRef}
                 style={{ flex: 1 }}
-                showsVerticalScrollIndicator={true}
-            >
-
-                {Array.from({ length: TOTAL_HOURS }).map((_, hour) => (
-                    <><TView key={hour} pl={10} pr={10} style={{
-                        height: HOUR_BLOCK_HEIGHT,
-                        borderBottomWidth: 1,
-                    }} flexDirection="row">
-                        <TText color='text' size={12} mr={5} mt={35} style={{ width: 40 }}>{`${hour}:00`}</TText>
-                        <TView flexDirection="row" flex={1}>
-                            <For each={courses} key="id">
-                                {course =>
-                                    course.data.periods
-                                        .filter(
-                                            period =>
-                                                period.start >= hour * 60 &&
-                                                period.start < (hour + 1) * 60 &&
-                                                period.dayIndex === getCurrentDay()
-                                        )
-                                        .map((period, index, filteredPeriods) => {
-                                            return (
-                                                <Day
-                                                    key={index}
-                                                    period={period}
-                                                    course={course}
-                                                    user={user}
-                                                    filteredPeriods={filteredPeriods}
-                                                    index={index}
-                                                />
-
-                                            );
-                                        })
-                                }
-                            </For>
-                        </TView>
+                showsVerticalScrollIndicator={true}>
+                <TView flexDirection="row">
+                    <TView style={(format == 'week' && { width: '7%' }) || (format == 'day' && { width: '14%' })}>
+                        {Array.from({ length: TOTAL_HOURS }).map((_, hour) => (
+                            <TView key={hour} alignItems='center' justifyContent='center' bt={1} bb={1} borderColor='yellow' style={{ height: HOUR_BLOCK_HEIGHT }}>
+                                <TText color='text' size={12}>{`${hour}:00`}</TText>
+                            </TView>
+                        ))}
                     </TView>
-                        <TView
-                            backgroundColor='red'
-                            style={{
-                                position: 'absolute',
-                                width: '100%',
-                                height: 2,
-                                top: (currentMinutes / 60) * HOUR_BLOCK_HEIGHT,
-                            }}
-                        />
-                    </>
-                ))}
+
+                    {format === "day" && renderDay(getCurrentDay())}
+                    {format === "week" && (
+                        <TView flexDirection="row" style={{ flex: 1 }}>
+                            {DAY_ORDER.map(dayIndex => renderDay(dayIndex))}
+                        </TView>
+                    )}
+                </TView>
             </ScrollView>
         </TView>
-
     );
 };

--- a/edweiss-app/components/core/calendar.tsx
+++ b/edweiss-app/components/core/calendar.tsx
@@ -67,10 +67,10 @@ export const Calendar = ({ courses, type }: { courses: { id: string; data: Cours
     const renderDay = (dayIndex: number) => (
         <TView key={dayIndex} flex={1} >
             {Array.from({ length: TOTAL_HOURS }).map((_, hour) => (
-                <TView key={hour} bb={1} bl={1} borderColor='pink' p={10} style={{
+                <TView key={hour} bb={1} bl={1} borderColor='pink' style={{
                     height: HOUR_BLOCK_HEIGHT,
                 }} flexDirection="row">
-                    <TView flexDirection="row" flex={1}>
+                    <TView flexDirection="row" flex={1} >
                         <For each={courses} key="id">
                             {course =>
                                 course.data.periods

--- a/edweiss-app/components/core/formatTime.tsx
+++ b/edweiss-app/components/core/formatTime.tsx
@@ -1,12 +1,9 @@
 const formatTime = (minutes: number) => {
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
-
     if (hours > 23) {
         return "23:59";
     }
-
     return `${hours}:${mins < 10 ? '0' : ''}${mins}`;
 };
-
 export default formatTime;


### PR DESCRIPTION
### Pull Request: MyCalendar Page Implementation

This pull request adds the MyCalendar page, a dedicated calendar view that allows users to view their enrolled courses with flexible orientation options. The calendar can be displayed in a vertical view for a single day or in a horizontal view for an entire week. It is also possible to lock the orientation to a specific layout if needed.

**Additional Details**
The current calendar colors are limited by the theme in place and despite several attempts, I am unable to change them at this time. I plan to add more color customization options in a future update to improve the visual appeal.
<img src="https://github.com/user-attachments/assets/44140958-abd4-4a8e-8f17-7210edaaa4a0" width="200px">

<img src="https://github.com/user-attachments/assets/58222265-5ba2-46f4-afee-5475dfc21788" width="200px">

<img src="https://github.com/user-attachments/assets/f353685d-db23-4bdf-be50-d01561f3b953" width="400px">

