### PR TITLE
Fix the duplicate todo problem.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: "Run Application Tests"
 
 on:
   push:
-    branches: [master, main, feature/*, refractor/*]
+    branches: [master, main, feature/*, refractor/*, bugfix/*]
   pull_request:
-    branches: [master, main, feature/*, refractor/*]
+    branches: [master, main, feature/*, refractor/*, bugfix/*]
 
 defaults:
   run:

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .vscode/launch.json
 .vscode/settings.json
 .vscode/settings.json
-edweiss-app/package.json
 edweiss-app/package-lock.json
 edweiss-app/package-lock.json
 edweiss-app/app.config.ts
@@ -14,5 +13,4 @@ edweiss-app/package-lock.json
 .vscode/settings.json
 edweiss-app/package-lock.json
 .vscode/settings.json
-edweiss-app/package.json
 

--- a/edweiss-app/__test__/utils/time.test.ts
+++ b/edweiss-app/__test__/utils/time.test.ts
@@ -98,4 +98,58 @@ describe('Time Utilities Tests Suites', () => {
             expect(Time.isTomorrow(yesterday)).toBe(false);
         });
     });
+
+    describe('Check margin day gap for isToday', () => {
+        const duringDayDelta = 100;
+        it('should return true if the day is within today', () => {
+            const today = new Date(new Date().setHours(0, 0, 0, 0) + duringDayDelta);
+            expect(Time.isToday(today)).toBe(true);
+        });
+
+        it('should return false for yesterday\'s date', () => {
+            const yesterday = new Date(new Date().setHours(0, 0, 0, 0) - 86400000 + duringDayDelta);
+            expect(Time.isToday(yesterday)).toBe(false);
+        });
+
+        it('should return false for tomorrow\'s date', () => {
+            const tomorrow = new Date(new Date().setHours(0, 0, 0, 0) + 86400000 + duringDayDelta);
+            expect(Time.isToday(tomorrow)).toBe(false);
+        });
+    });
+    describe('Check margin day gap for isTomorrow', () => {
+        const duringDayDelta = 100;
+        it('should return true if the day is within tomorrow', () => {
+            const tomorrow = new Date(new Date().setHours(0, 0, 0, 0) + 86400000 + duringDayDelta);
+            expect(Time.isTomorrow(tomorrow)).toBe(true);
+        });
+
+        it('should return false for today\'s date', () => {
+            const today = new Date(new Date().setHours(0, 0, 0, 0) + duringDayDelta);
+            expect(Time.isTomorrow(today)).toBe(false);
+        });
+
+        it('should return false for yesterday\'s date', () => {
+            const yesterday = new Date(new Date().setHours(0, 0, 0, 0) - 86400000 + duringDayDelta);
+            expect(Time.isTomorrow(yesterday)).toBe(false);
+        });
+    });
+
+    describe('Check margin day gap for wasYesterday', () => {
+        const duringDayDelta = 100;
+        it('should return true if the day is within yesterday', () => {
+            const yesterday = new Date(new Date().setHours(0, 0, 0, 0) - 86400000 + duringDayDelta);
+            expect(Time.wasYesterday(yesterday)).toBe(true);
+        });
+
+        it('should return false for today\'s date', () => {
+            const today = new Date(new Date().setHours(0, 0, 0, 0) + duringDayDelta);
+            expect(Time.wasYesterday(today)).toBe(false);
+        });
+
+        it('should return false for tomorrow\'s date', () => {
+            const tomorrow = new Date(new Date().setHours(0, 0, 0, 0) + 86400000 + duringDayDelta);
+            expect(Time.wasYesterday(tomorrow)).toBe(false);
+        });
+    });
+
 });

--- a/edweiss-app/app/(app)/todo/index.tsx
+++ b/edweiss-app/app/(app)/todo/index.tsx
@@ -57,7 +57,7 @@ const TodoListScreen: ApplicationRoute = () => {
 
             <RouteHeader title={t(`todo:todolist_header`)} right={<HeaderButton icon="options-outline" testID='filter-button' onPress={() => modalRefFilter.current?.present()} />} />
 
-            {todos_filtered.length > 0 ? (<GestureHandlerRootView style={{ flex: 1 }}><NativeViewGestureHandler><ScrollView>{todos_filtered.map((todo) => (<TodoDisplay key={todo.id} id={todo.id} todo={todo.data} setTodoToDisplay={setTodoToDisplay} modalRef={modalRefTodoInfo} />))} <TView mt={50} mb={75}></TView></ScrollView></NativeViewGestureHandler></GestureHandlerRootView>)
+            {todos_filtered.length > 0 ? (<GestureHandlerRootView style={{ flex: 1 }}><NativeViewGestureHandler><ScrollView>{todos_filtered.map((todo) => (<TodoDisplay key={todo.id} id={todo.id} todo={todo.data} setTodoToDisplay={setTodoToDisplay} modalRef={modalRefTodoInfo} />))}</ScrollView></NativeViewGestureHandler></GestureHandlerRootView>)
                 :
                 (
                     <TView

--- a/edweiss-app/components/courses/AssignmentDisplay.tsx
+++ b/edweiss-app/components/courses/AssignmentDisplay.tsx
@@ -10,11 +10,10 @@ import { dateFormats, timeInMS } from '@/constants/Time';
 import { Assignment } from '@/model/school/courses';
 import Todolist from '@/model/todo';
 import { Time as OurTime } from '@/utils/time';
-import { Timestamp } from '@react-native-firebase/firestore';
-import { router } from 'expo-router';
 import { useRef } from 'react';
 import { Swipeable } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
+import { Timestamp } from '../../model/time';
 import TTouchableOpacity from '../core/containers/TTouchableOpacity';
 import Icon from '../core/Icon';
 
@@ -82,7 +81,7 @@ const AssignmentDisplay: ReactComponent<{ item: AssignmentWithColor, index: numb
         isSwipeable ?
             <Swipeable
                 ref={(ref) => { swipeableRefs.current[index] = ref; }} renderRightActions={renderRightActions} onSwipeableOpen={(direction) => {
-                    if (direction === 'right') { console.log(`Swipe detected on assignment: ${item.name}`); Toast.show({ type: 'success', text1: t(`course:toast_added_to_todo_text1`), text2: t(`course:toast_added_to_todo_text2`), }); swipeableRefs.current[index]?.close(); }
+                    if (direction === 'right') { console.log(`Swipe detected on assignment: ${item.name}`); saveTodo(item.name, item.dueDate, item.type); swipeableRefs.current[index]?.close(); }
                 }
                 }>
                 {assignmentView()}
@@ -104,11 +103,16 @@ async function saveTodo(name: string, dueDate: Timestamp, description: string) {
         });
 
         if (res.status) {
-            router.back();
             Toast.show({
                 type: 'success',
                 text1: t(`course:toast_added_to_todo_text1`),
                 text2: t(`course:toast_added_to_todo_text2`)
+            });
+        } else if (res.error === "duplicate_todo") {
+            Toast.show({
+                type: 'info',
+                text1: t(`todo:already_existing_todo_toast_title`),
+                text2: t(`todo:already_existing_todo_toast_funny`)
             });
         } else {
             Toast.show({

--- a/edweiss-app/components/todo/abstractTodoEditor.tsx
+++ b/edweiss-app/components/todo/abstractTodoEditor.tsx
@@ -68,7 +68,7 @@ export const AbstractTodoEditor: React.FC<{
     if (editable) {
         downButtonIconName = "create";
         downButtonTitle = t(`todo:edit_button`);
-        screenTitle = t(`todo:create_header`);
+        screenTitle = t(`todo:edit_header`);
         downButtonAction = editTodoAction;
     }
 
@@ -109,6 +109,12 @@ export const AbstractTodoEditor: React.FC<{
                     text1: name + t(`todo:was_added_toast`),
                     text2: t(`todo:funny_phrase_on_add`)
                 });
+            } else if (res.error === "duplicate_todo") {
+                Toast.show({
+                    type: 'info',
+                    text1: t(`todo:already_existing_todo_toast_title`),
+                    text2: t(`todo:already_existing_todo_toast_funny`)
+                });
             } else {
                 Toast.show({
                     type: 'error',
@@ -145,6 +151,12 @@ export const AbstractTodoEditor: React.FC<{
                     type: 'success',
                     text1: name + t(`todo:was_edited_toast`),
                     text2: t(`todo:funny_phrase_on_edit`)
+                });
+            } else if (res.error === "duplicate_todo") {
+                Toast.show({
+                    type: 'info',
+                    text1: t(`todo:already_existing_todo_toast_title`),
+                    text2: t(`todo:already_existing_todo_toast_funny`)
                 });
             } else {
                 Toast.show({

--- a/edweiss-app/components/todo/abstractTodoEditor.tsx
+++ b/edweiss-app/components/todo/abstractTodoEditor.tsx
@@ -136,7 +136,7 @@ export const AbstractTodoEditor: React.FC<{
         if (!id) return;
 
 
-        if (editable) {
+        try {
             const res = await callFunction(Functions.updateTodo, {
                 name: name, description: description === "" ? undefined : description, status: status,
                 dueDate: (!(dateChanged || timeChanged)) ? undefined : date.toISOString(),
@@ -165,7 +165,7 @@ export const AbstractTodoEditor: React.FC<{
                     text2: t(`todo:couldnot_edit_toast`)
                 });
             }
-        } else {
+        } catch (error) {
             Toast.show({
                 type: 'error',
                 text1: t(`todo:error_toast_title`),

--- a/edweiss-app/locales/en/todo.json
+++ b/edweiss-app/locales/en/todo.json
@@ -48,7 +48,9 @@
 	"couldnot_edit_toast": "Couldn't edit the Todo, please try again.",
 	"was_deleted_toast": " was deleted !",
 	"funny_phrase_on_delete": "Gone, but not forgotten!",
-	"couldnot_delete_toast": "Couldn't delete the Todo, please try again."
+	"couldnot_delete_toast": "Couldn't delete the Todo, please try again.",
+	"already_existing_todo_toast_title": "This todo is already present in your todo list", 
+	"already_existing_todo_toast_funny": "Déjà vu, you already have this one!"
 
 
 }

--- a/edweiss-app/model/todo.ts
+++ b/edweiss-app/model/todo.ts
@@ -13,7 +13,7 @@ import { Timestamp } from './time';
 
 
 // ------------------------------------------------------------
-// ---------------------  To do Namespace  --------------------
+// ---------------------  To do Namespace  ---------------------
 // ------------------------------------------------------------
 namespace Todolist {
 
@@ -28,8 +28,8 @@ namespace Todolist {
 
 
     export const Functions = FunctionFolder("todolist", {
-        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error'>("createTodo"),
-        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error'>("updateTodo"),
+        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("createTodo"),
+        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("updateTodo"),
         deleteTodo: FunctionOf<{ id: string; }, {}, 'invalid_id' | 'firebase_error'>("deleteTodo")
     });
 

--- a/edweiss-app/utils/time.ts
+++ b/edweiss-app/utils/time.ts
@@ -29,7 +29,9 @@ export namespace Time {
 	}
 
 	export function isToday(date: Date): boolean {
-		return sameDay(date, new Date());
+		const today = new Date(new Date().setHours(0, 0, 0, 0));
+		const dateToCheck = new Date(new Date(date).setHours(0, 0, 0, 0));
+		return today.toDateString() === dateToCheck.toDateString();
 	}
 
 	export function wasYesterday(date: Date): boolean {

--- a/edweiss-firebase/functions/src/functions/todolist/createTodo.ts
+++ b/edweiss-firebase/functions/src/functions/todolist/createTodo.ts
@@ -33,6 +33,13 @@ export const createTodo = onAuthentifiedCall(Functions.createTodo, async (userId
 
     const todoCollection = CollectionOf<Todo>(`users/${userId}/todos`);
 
+    const existingTodos = await todoCollection.where('name', '==', name).get();
+
+    if (!existingTodos.empty) {
+        return fail("duplicate_todo");
+    }
+
+
     const todoToInsert: Todo = {
         name: name,
         status: status,

--- a/edweiss-firebase/functions/src/functions/todolist/updateTodo.ts
+++ b/edweiss-firebase/functions/src/functions/todolist/updateTodo.ts
@@ -31,6 +31,14 @@ export const updateTodo = onAuthentifiedCall(Functions.updateTodo, async (userId
     if (todo == undefined)
         return fail("firebase_error");
 
+    const todoCollection = CollectionOf<Todo>(`users/${userId}/todos`);
+
+    const existingTodos = await todoCollection.where('name', '==', args.name).get();
+
+    if (!existingTodos.empty) {
+        return fail("duplicate_todo");
+    }
+
     const updatedFields: Partial<Todo> = {};
     if (args.name) updatedFields.name = args.name;
     if (args.status) updatedFields.status = args.status;

--- a/edweiss-firebase/functions/src/model/todo.ts
+++ b/edweiss-firebase/functions/src/model/todo.ts
@@ -28,8 +28,8 @@ namespace Todolist {
 
 
     export const Functions = FunctionFolder("todolist", {
-        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error'>("createTodo"),
-        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error'>("updateTodo"),
+        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("createTodo"),
+        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("updateTodo"),
         deleteTodo: FunctionOf<{ id: string; }, {}, 'invalid_id' | 'firebase_error'>("deleteTodo")
     });
 

--- a/edweiss-web/src/model/todo.ts
+++ b/edweiss-web/src/model/todo.ts
@@ -28,8 +28,8 @@ namespace Todolist {
 
 
     export const Functions = FunctionFolder("todolist", {
-        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error'>("createTodo"),
-        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error'>("updateTodo"),
+        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("createTodo"),
+        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("updateTodo"),
         deleteTodo: FunctionOf<{ id: string; }, {}, 'invalid_id' | 'firebase_error'>("deleteTodo")
     });
 

--- a/model/src/todo.ts
+++ b/model/src/todo.ts
@@ -28,8 +28,8 @@ namespace Todolist {
 
 
     export const Functions = FunctionFolder("todolist", {
-        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error'>("createTodo"),
-        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error'>("updateTodo"),
+        createTodo: FunctionOf<{ name: string; description?: string; status: TodoStatus; dueDate?: string; }, {}, 'invalid_arg' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("createTodo"),
+        updateTodo: FunctionOf<{ name?: string; description?: string; status?: TodoStatus; dueDate?: string; id: string; }, {}, 'invalid_arg' | 'invalid_id' | 'error_date' | 'firebase_error' | 'duplicate_todo'>("updateTodo"),
         deleteTodo: FunctionOf<{ id: string; }, {}, 'invalid_id' | 'firebase_error'>("deleteTodo")
     });
 


### PR DESCRIPTION
**Description**
This pull request fixes the bug related to the duplicate to-do problem. As point out during the last milestone, with the current configuration, one could create as many to-dos with the same name, which is a unwanted side effect. Moreover, this PR solves equally the `isToday` function in the time framework. In fact the current function delivered checked if the date were exactly the same, which is too strict as if one has a todo 

**Feature checklist**
- Updated the cloud function to support and handle to-do duplication at there level
- Updated the `abstractTodoEditor` to support in create/edit mode the duplication `Toast` and exceptions
- Updated the `time`  `isToday` to support the day margin gap. This is useful so that the to-dos of the day are shown up in a 24h and not must be equal to the exact `Timestamp` in the `dueDate`.
- Provide integration to `AssignmentDisplay` and error handling for the assignment to go directly in the to-do list screen.
- Updated test suites for the time `abstractTodoEditor` 
- Updated the test suites for the `time` utils framework.

**Issues**
- When deploying the cloud function, an error occured when it was related to the fact that I had a broken version of the `notif.ts` and also missing the secret `OPENAI_API_KEY`. Once I realized this and `git pull --rebase` this did the trick. I had to resolve conflict and add an `.env`file, but after this everything was working fine. 

**Coverage**

| File Name   | Coverage   | Line Miss | Comment     |
|----------------|:-----------------:|:-------------------:|---------------------------------|
| `abstractTodoEditor.tsx` | 96.7          |  272, 289           | 260 & 277 are related to the `dateTimePicker`. When testing I just wanted to check if it pop's up and update the entry value. To covert those lines we would have to update the mock to provide a close event handling.      |
| `time.ts`  | 100          |  N/A |    the test suite has been updated to support the margin gap feature|

**Previous Behaviour Demo**


https://github.com/user-attachments/assets/38801144-dbce-4bb2-a945-66ce6485e642


**Fixed Behaviour Demo**


https://github.com/user-attachments/assets/57e08f79-82c4-4d37-892e-8a723103350d

** Integration with `AssignmentDisplay`**

https://github.com/user-attachments/assets/a48657b3-6648-43af-9a73-7ee77013bb89


