### PR TITLE
Adds tests for the standard library + Remove configuration files from the SonarCloud code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             -Dsonar.organization=snowwhiteepfl
             -Dsonar.sources=./edweiss-app/        
             -Dsonar.javascript.lcov.reportPaths=./edweiss-app/coverage/lcov.info
-            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**
+            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**,**/**_layout.tsx
         if: always()
 
       - name: Upload coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             -Dsonar.organization=snowwhiteepfl
             -Dsonar.sources=./edweiss-app/        
             -Dsonar.javascript.lcov.reportPaths=./edweiss-app/coverage/lcov.info
-            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**
+            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**,**/model/**
         if: always()
 
       - name: Upload coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             -Dsonar.organization=snowwhiteepfl
             -Dsonar.sources=./edweiss-app/        
             -Dsonar.javascript.lcov.reportPaths=./edweiss-app/coverage/lcov.info
-            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**,**/**_layout.tsx
+            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**
         if: always()
 
       - name: Upload coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
             -Dsonar.organization=snowwhiteepfl
             -Dsonar.sources=./edweiss-app/        
             -Dsonar.javascript.lcov.reportPaths=./edweiss-app/coverage/lcov.info
-            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/android/**,**/.gitignore,**/app.config.ts,**/babel.config.js,**/hooks/**,**/declarations.d.ts,**/eas.json,**/expo-env.d.ts,**/metro.config.js,**/metro.config.ts,**/package-lock.json,**/package.json,**/tsconfig.json
+            -Dsonar.exclusions=**/node_modules/**,**/coverage/**,**/__test__/**,**/.expo/**,**/.gitignore,**/**config.js,**/**config.ts,**/**config.tsx,**/hooks/**,**/**.d.ts,**/config/firebase.ts,**/eas.json,**/expo-env.d.ts,**/package-lock.json,**/package.json,**/**.json,**/locales/**,**/android/**,**/ios/**
         if: always()
 
       - name: Upload coverage report

--- a/edweiss-app/__test__/config/SyncStorage.test.ts
+++ b/edweiss-app/__test__/config/SyncStorage.test.ts
@@ -1,0 +1,64 @@
+import { SyncStorageSingleton } from '@/config/SyncStorage';
+
+const SyncStorage = new SyncStorageSingleton();
+
+type KeyValuePair = [string, string | null];
+
+const Disk: KeyValuePair[] = [
+	["key1", "value1"],
+	["key2", "value2"],
+	["key3", "value3"],
+]
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+	setItem: jest.fn(),
+	getItem: jest.fn(),
+	removeItem: jest.fn(),
+	getAllKeys: jest.fn(() => {
+		return {
+			then(onfulfilled: (keys: string[]) => void) {
+				onfulfilled(Disk.map(pair => pair[0]));
+			},
+		}
+	}),
+	multiGet: jest.fn(() => {
+		return {
+			then(onfulfilled: (kvp: KeyValuePair[]) => void) {
+				onfulfilled(Disk);
+			},
+		}
+	})
+}));
+
+describe("SyncStorage", () => {
+	it("should return nothing when init", () => {
+		expect(SyncStorage.init()).toBeUndefined();
+		SyncStorage.getAllKeys().forEach(key => {
+			expect(key).toBeTruthy();
+		})
+	});
+
+	it("should store all the values from disk to memory", () => {
+		Disk.forEach(pair => {
+			expect(SyncStorage.get(pair[0])).toBe(pair[1]);
+		});
+	});
+
+	it("should give back the same value after setting it", () => {
+		SyncStorage.set("key", "value");
+		expect(SyncStorage.has("key")).toBeTruthy();
+		expect(SyncStorage.get("key")).toBe("value");
+		expect(SyncStorage.remove("key")).toBeUndefined();
+		expect(SyncStorage.get("key")).toBeUndefined();
+	});
+
+	it("should give the default value if it is not present on disk (no write)", () => {
+		expect(SyncStorage.getOrDefaultNoWrite(Disk[0][0], "new_value")).toBe(Disk[0][1]);
+		expect(SyncStorage.getOrDefaultNoWrite("not_in_disk", "new_value")).toBe("new_value");
+	});
+
+	it("should give the default value if it is not present on disk", () => {
+		expect(SyncStorage.getOrDefault("not_in_disk2", "new_value")).toBe("new_value");
+		expect(SyncStorage.getOrDefault("not_in_disk2", "lost")).toBe("new_value");
+	});
+});

--- a/edweiss-app/__test__/constants/Sizes.test.ts
+++ b/edweiss-app/__test__/constants/Sizes.test.ts
@@ -1,0 +1,121 @@
+import { PredefinedSizes, computeBorders, computeMargins, computePaddings, computeSize, computeSizeOpt } from '@/constants/Sizes';
+import { ViewStyle } from 'react-native';
+
+describe("Sizes", () => {
+	const sizes: PredefinedSizes = {
+		xs: 1,
+		sm: 2,
+		md: 3,
+		lg: 4,
+		xl: 5
+	};
+
+	it("should correctly compute sizes", () => {
+		expect(computeSize("xs", sizes)).toBe(sizes.xs);
+		expect(computeSize("sm", sizes)).toBe(sizes.sm);
+		expect(computeSize("md", sizes)).toBe(sizes.md);
+		expect(computeSize("lg", sizes)).toBe(sizes.lg);
+		expect(computeSize("xl", sizes)).toBe(sizes.xl);
+	});
+
+	it("should correctly compute optional sizes", () => {
+		expect(computeSizeOpt(undefined, sizes)).toBe(undefined);
+		expect(computeSizeOpt("xs", sizes)).toBe(sizes.xs);
+		expect(computeSizeOpt("sm", sizes)).toBe(sizes.sm);
+		expect(computeSizeOpt("md", sizes)).toBe(sizes.md);
+		expect(computeSizeOpt("lg", sizes)).toBe(sizes.lg);
+		expect(computeSizeOpt("xl", sizes)).toBe(sizes.xl);
+	});
+
+	it("should correctly compute margins", () => {
+		const margins1 = computeMargins({
+			m: 1,
+			ml: 2,
+			mr: 3,
+			mb: 4,
+			mt: 5,
+			mx: 6,
+			my: 7
+		});
+
+		expect(margins1).toStrictEqual<ViewStyle>({
+			margin: 1,
+			marginLeft: 2,
+			marginRight: 3,
+			marginBottom: 4,
+			marginTop: 5,
+			marginHorizontal: 6,
+			marginVertical: 7
+		});
+
+		const margins2 = computeMargins({
+			mx: 10,
+			my: 20
+		});
+
+		expect(margins2).toStrictEqual<ViewStyle>({
+			margin: undefined,
+			marginLeft: undefined,
+			marginRight: undefined,
+			marginBottom: undefined,
+			marginTop: undefined,
+			marginHorizontal: 10,
+			marginVertical: 20
+		});
+	});
+
+	it("should correctly compute paddings", () => {
+		const paddings1 = computePaddings({
+			p: 1,
+			pl: 2,
+			pr: 3,
+			pb: 4,
+			pt: 5,
+			px: 6,
+			py: 7
+		});
+
+		expect(paddings1).toStrictEqual<ViewStyle>({
+			padding: 1,
+			paddingLeft: 2,
+			paddingRight: 3,
+			paddingBottom: 4,
+			paddingTop: 5,
+			paddingHorizontal: 6,
+			paddingVertical: 7
+		});
+
+		const paddings2 = computePaddings({
+			px: 10,
+			py: 20
+		});
+
+		expect(paddings2).toStrictEqual<ViewStyle>({
+			padding: undefined,
+			paddingLeft: undefined,
+			paddingRight: undefined,
+			paddingBottom: undefined,
+			paddingTop: undefined,
+			paddingHorizontal: 10,
+			paddingVertical: 20
+		});
+	});
+
+	it("should correctly compute borders", () => {
+		const borders1 = computeBorders({
+			b: 1,
+			bl: 2,
+			br: 3,
+			bb: 4,
+			bt: 5
+		});
+
+		expect(borders1).toStrictEqual<ViewStyle>({
+			borderWidth: 1,
+			borderLeftWidth: 2,
+			borderRightWidth: 3,
+			borderBottomWidth: 4,
+			borderTopWidth: 5
+		});
+	});
+});

--- a/edweiss-app/__test__/constants/Style.test.ts
+++ b/edweiss-app/__test__/constants/Style.test.ts
@@ -1,0 +1,20 @@
+
+import { computeContainerStyle } from '@/constants/Style';
+
+describe("Style", () => {
+	it("should correctly compute container styles", () => {
+		const style = computeContainerStyle({
+			radius: 10,
+			alignItems: "flex-start",
+			justifyContent: "space-between",
+			flexColumnGap: 13,
+			flexRowGap: 15
+		}, "red", "blue");
+
+		expect(style.borderRadius).toBe(10);
+		expect(style.alignItems).toBe("flex-start");
+		expect(style.justifyContent).toBe("space-between");
+		expect(style.columnGap).toBe(13);
+		expect(style.rowGap).toBe(15);
+	});
+});

--- a/edweiss-app/__test__/contexts/__snapshots__/auth.test.tsx.snap
+++ b/edweiss-app/__test__/contexts/__snapshots__/auth.test.tsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Authentication Context Provider should render correctly 1`] = `
+<Text>
+  Some text
+</Text>
+`;

--- a/edweiss-app/__test__/contexts/auth.test.tsx
+++ b/edweiss-app/__test__/contexts/auth.test.tsx
@@ -1,0 +1,41 @@
+import { AuthSessionProvider } from '@/contexts/auth';
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+const firebaseUser = { displayName: "John Doe", uid: 'firebase-test-uid', email: 'firebase-test@example.com' };
+
+jest.mock('@react-native-firebase/auth', () => ({
+	__esModule: true,
+	currentUser: firebaseUser,
+	default: jest.fn(() => ({
+		onAuthStateChanged: jest.fn((callback: (user: FirebaseAuthTypes.User | null) => void) => {
+			callback(firebaseUser as FirebaseAuthTypes.User);
+		})
+	}))
+}));
+
+// const UsingAuthContext: ReactComponent<{}> = () => {
+// 	const obj = useAuth();
+// 	console.log(obj);
+// 	return (<Text>{obj.authUser.displayName}</Text>);
+// };
+
+describe("Authentication Context Provider", () => {
+	it("should render correctly", () => {
+		const Provider = render(<AuthSessionProvider><Text>Some text</Text></AuthSessionProvider>).toJSON();
+		expect(Provider).toMatchSnapshot();
+	});
+
+	// it("should not useAuth", () => {
+	// 	const Component = render(
+	// 		<AuthSessionProvider>
+	// 			<UsingAuthContext />
+	// 		</AuthSessionProvider>
+	// 	).toJSON();
+
+	// 	act(() => {
+	// 		expect(Component).toMatchSnapshot();
+	// 	});
+	// });
+});

--- a/edweiss-app/config/SyncStorage.ts
+++ b/edweiss-app/config/SyncStorage.ts
@@ -6,9 +6,9 @@ function isTemporary(key: string) {
 
 /**
  * Do not instantiate this class, it is a singleton.
- * Use the already defined below `syncStorage` object.
+ * Use the already defined below `SyncStorage` object.
  */
-class SyncStorageSingleton {
+export class SyncStorageSingleton {
 	data: Map<string, any> = new Map();
 
 	loading: boolean = true;

--- a/edweiss-app/constants/Colors.ts
+++ b/edweiss-app/constants/Colors.ts
@@ -69,7 +69,7 @@ const Colors = {
 		// color16: "#4D1590",
 		// color17: "#45074A",
 		// color18: "#42041D",
-	},
+	} as const,
 	dark: {
 		transparent: '#0000',
 		constantWhite: "#ffffff",
@@ -125,8 +125,8 @@ const Colors = {
 		// color16: "#765999", //
 		// color17: "#451F48",
 		// color18: "#441B2C", //
-	},
-};
+	} as const,
+} as const;
 
 export default Colors;
 
@@ -135,4 +135,4 @@ export const courseColors: Record<CourseTimePeriodType, Color> = {
 	exercises: 'pink',
 	lab: 'green',
 	project: 'peach',
-};
+} as const;

--- a/edweiss-app/constants/Sizes.ts
+++ b/edweiss-app/constants/Sizes.ts
@@ -1,3 +1,4 @@
+import { ViewStyle } from 'react-native';
 
 export type PredefinedSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
@@ -31,8 +32,6 @@ export interface BorderProps {
 	bb?: Size,
 	bl?: Size,
 	br?: Size,
-	bx?: Size,
-	by?: Size;
 }
 
 export type BoxModelProps = PaddingProps & MarginProps & BorderProps;
@@ -113,45 +112,37 @@ export function computeSizeOpt(size: Size | undefined, sizes: PredefinedSizes): 
 	return computeSize(size, sizes);
 }
 
-export function computePaddings(paddings: PaddingProps) {
-	const p = computeSizeOpt(paddings.p, paddingSizes);
-	const px = computeSizeOpt(paddings.px, paddingSizes);
-	const py = computeSizeOpt(paddings.py, paddingSizes);
-
+export function computePaddings(paddings: PaddingProps): ViewStyle {
 	return {
-		padding: p,
-		paddingTop: paddings.pt == undefined ? (py ?? p) : computeSizeOpt(paddings.pt, paddingSizes),
-		paddingBottom: paddings.pb == undefined ? (py ?? p) : computeSizeOpt(paddings.pb, paddingSizes),
-		paddingLeft: paddings.pl == undefined ? (px ?? p) : computeSizeOpt(paddings.pl, paddingSizes),
-		paddingRight: paddings.pr == undefined ? (px ?? p) : computeSizeOpt(paddings.pr, paddingSizes),
+		padding: computeSizeOpt(paddings.p, paddingSizes),
+		paddingTop: computeSizeOpt(paddings.pt, paddingSizes),
+		paddingBottom: computeSizeOpt(paddings.pb, paddingSizes),
+		paddingLeft: computeSizeOpt(paddings.pl, paddingSizes),
+		paddingRight: computeSizeOpt(paddings.pr, paddingSizes),
+		paddingHorizontal: computeSizeOpt(paddings.px, paddingSizes),
+		paddingVertical: computeSizeOpt(paddings.py, paddingSizes)
 	};
 }
 
-export function computeMargins(margins: MarginProps) {
-	const m = computeSizeOpt(margins.m, marginSizes);
-	const mx = computeSizeOpt(margins.mx, marginSizes);
-	const my = computeSizeOpt(margins.my, marginSizes);
-
+export function computeMargins(margins: MarginProps): ViewStyle {
 	return {
-		margin: m,
-		marginTop: margins.mt == undefined ? (my ?? m) : computeSizeOpt(margins.mt, marginSizes),
-		marginBottom: margins.mb == undefined ? (my ?? m) : computeSizeOpt(margins.mb, marginSizes),
-		marginLeft: margins.ml == undefined ? (mx ?? m) : computeSizeOpt(margins.ml, marginSizes),
-		marginRight: margins.mr == undefined ? (mx ?? m) : computeSizeOpt(margins.mr, marginSizes),
+		margin: computeSizeOpt(margins.m, marginSizes),
+		marginTop: computeSizeOpt(margins.mt, marginSizes),
+		marginBottom: computeSizeOpt(margins.mb, marginSizes),
+		marginLeft: computeSizeOpt(margins.ml, marginSizes),
+		marginRight: computeSizeOpt(margins.mr, marginSizes),
+		marginHorizontal: computeSizeOpt(margins.mx, marginSizes),
+		marginVertical: computeSizeOpt(margins.my, marginSizes)
 	};
 }
 
-export function computeBorders(borders: BorderProps) {
-	const b = computeSizeOpt(borders.b, borderSizes);
-	const bx = computeSizeOpt(borders.bx, borderSizes);
-	const by = computeSizeOpt(borders.by, borderSizes);
-
+export function computeBorders(borders: BorderProps): ViewStyle {
 	return {
-		borderWidth: b,
-		borderTopWidth: borders.bt == undefined ? (by ?? b) : computeSizeOpt(borders.bt, borderSizes),
-		borderBottomWidth: borders.bb == undefined ? (by ?? b) : computeSizeOpt(borders.bb, borderSizes),
-		borderLeftWidth: borders.bl == undefined ? (bx ?? b) : computeSizeOpt(borders.bl, borderSizes),
-		borderRightWidth: borders.br == undefined ? (bx ?? b) : computeSizeOpt(borders.br, borderSizes),
+		borderWidth: computeSizeOpt(borders.b, borderSizes),
+		borderTopWidth: computeSizeOpt(borders.bt, borderSizes),
+		borderBottomWidth: computeSizeOpt(borders.bb, borderSizes),
+		borderLeftWidth: computeSizeOpt(borders.bl, borderSizes),
+		borderRightWidth: computeSizeOpt(borders.br, borderSizes),
 	};
 }
 

--- a/edweiss-app/constants/Style.ts
+++ b/edweiss-app/constants/Style.ts
@@ -25,7 +25,7 @@ export type ContainerProps = & LightDarkProps & BoxModelProps & {
 
 export type ContainerStyle = StyleProp<ViewStyle>;
 
-export function computeContainerStyle(props: ContainerProps, backgroundColor: string | undefined, borderColor: string | undefined): ContainerStyle {
+export function computeContainerStyle(props: ContainerProps, backgroundColor: string | undefined, borderColor: string | undefined): ViewStyle {
 	return {
 		backgroundColor,
 		flex: props.flex,

--- a/edweiss-app/constants/Time.ts
+++ b/edweiss-app/constants/Time.ts
@@ -1,19 +1,19 @@
 export const TIME_CONSTANTS = {
-    HOURS_IN_DAY: 24,
-    MINUTES_IN_HOUR: 60,
-    SECONDS_IN_MINUTE: 60,
-    MILLISECONDS_IN_SECOND: 1000,
-};
+	HOURS_IN_DAY: 24,
+	MINUTES_IN_HOUR: 60,
+	SECONDS_IN_MINUTE: 60,
+	MILLISECONDS_IN_SECOND: 1000,
+} as const;
 
 export const timeInMS = {
-    SECOND: TIME_CONSTANTS.MILLISECONDS_IN_SECOND,
-    MINUTE: TIME_CONSTANTS.MILLISECONDS_IN_SECOND * TIME_CONSTANTS.SECONDS_IN_MINUTE,
-    HOUR: TIME_CONSTANTS.MILLISECONDS_IN_SECOND * TIME_CONSTANTS.SECONDS_IN_MINUTE * TIME_CONSTANTS.MINUTES_IN_HOUR,
-    DAY: TIME_CONSTANTS.MILLISECONDS_IN_SECOND * TIME_CONSTANTS.SECONDS_IN_MINUTE * TIME_CONSTANTS.MINUTES_IN_HOUR * TIME_CONSTANTS.HOURS_IN_DAY,
-};
+	SECOND: TIME_CONSTANTS.MILLISECONDS_IN_SECOND,
+	MINUTE: TIME_CONSTANTS.MILLISECONDS_IN_SECOND * TIME_CONSTANTS.SECONDS_IN_MINUTE,
+	HOUR: TIME_CONSTANTS.MILLISECONDS_IN_SECOND * TIME_CONSTANTS.SECONDS_IN_MINUTE * TIME_CONSTANTS.MINUTES_IN_HOUR,
+	DAY: TIME_CONSTANTS.MILLISECONDS_IN_SECOND * TIME_CONSTANTS.SECONDS_IN_MINUTE * TIME_CONSTANTS.MINUTES_IN_HOUR * TIME_CONSTANTS.HOURS_IN_DAY,
+} as const;
 
 export const dateFormats = {
-    weekday: 'long' as 'long',  // Displays the day of the week, like "Friday"
-    month: 'long' as 'long',    // Displays the month, like "October"
-    day: 'numeric' as 'numeric',    // Displays the day of the month, like "12"
-};
+	weekday: 'long',  // Displays the day of the week, like "Friday"
+	month: 'long',    // Displays the month, like "October"
+	day: 'numeric',    // Displays the day of the month, like "12"
+} as const;

--- a/edweiss-app/package.json
+++ b/edweiss-app/package.json
@@ -15,11 +15,19 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.{ts,tsx,js,jsx}",
-      "!**/coverage/**",
+	  "!**/__test__/**",
+	  "!**/coverage/**",
       "!**/node_modules/**",
-      "!**/babel.config.js",
       "!**/expo-env.d.ts",
-      "!**/.expo/**"
+      "!**/.expo/**",
+	  "!**/android/**",
+	  "!**/ios/**",
+	  "!**/**config.js",
+	  "!**/**config.ts",
+	  "!**/**config.tsx",
+	  "!**/config/firebase.ts",
+	  "!**/locales/**.json",
+	  "!**/**.d.ts"
     ],
     "coverageDirectory": "./coverage",
     "coverageReporters": ["lcov", "text"]


### PR DESCRIPTION
Hello,

As its name suggests, this PR adds tests for the important bricks of the projects, such as Size props computation, Style props computation, synchronous storage and authentication context.

This PR also adds new files to the SonarCloud exclusion pattern, those are only files which make no sense to test such as :
 - Translation files (`common.json`, `home.json` etc.)
 - Application and Firebase configuration files
 - Android and iOS generated files
 - Typescript type declaration files (`*.d.ts`)
 - Model type declaration files (`model/`)