### PR TITLE
Fix Element Type Error and Refactor Test Mocks for RemoteControlScreen tests

### DIFF
--- a/edweiss-app/__test__/app/(app)/lectures/remotecontrol/index.test.tsx
+++ b/edweiss-app/__test__/app/(app)/lectures/remotecontrol/index.test.tsx
@@ -89,11 +89,6 @@ jest.mock('@react-native-firebase/messaging', () => ({
     })),
 }));
 
-// Mock react-native-pdf to prevent native calls
-jest.mock('react-native-pdf', () => {
-    return () => <div data-testid="mock-pdf-viewer">PDF Viewer Mock</div>;
-});
-
 // Updated mock for expo-screen-orientation
 jest.mock('expo-screen-orientation', () => ({
     lockAsync: jest.fn(),

--- a/edweiss-app/__test__/app/(app)/lectures/remotecontrol/index.test.tsx
+++ b/edweiss-app/__test__/app/(app)/lectures/remotecontrol/index.test.tsx
@@ -9,9 +9,12 @@
 // ------------------------------------------------------------
 
 
-import { setPortrait, startRecording, stopRecording } from '@/app/(app)/lectures/remotecontrol';
-import { FC, ReactNode } from 'react';
-
+import RemoteControlScreen, { setPortrait, startRecording, stopRecording } from '@/app/(app)/lectures/remotecontrol';
+import { usePrefetchedDynamicDoc } from '@/hooks/firebase/firestore';
+import Voice from '@react-native-voice/voice';
+import { act, render } from '@testing-library/react-native';
+import * as ScreenOrientation from 'expo-screen-orientation';
+import React, { ReactNode } from 'react';
 
 // ------------------------------------------------------------
 // -----------------  Mocking dependencies    -----------------
@@ -23,7 +26,13 @@ jest.mock('@/config/i18config', () => ({
 }));
 
 jest.mock('expo-router', () => ({
-    useLocalSearchParams: jest.fn(),
+    router: { push: jest.fn() },
+    Stack: {
+        Screen: jest.fn(({ options }) => (
+            <>{options.title}</> // Simulate rendering the title for the test
+        )),
+    },
+    useLocalSearchParams: jest.fn(() => ({ courseNameString: 'testCourse', lectureIdString: 'testLectureId' }))
 }));
 
 jest.mock('@react-navigation/native-stack', () => {
@@ -37,13 +46,8 @@ jest.mock('@react-navigation/native-stack', () => {
     };
 });
 
-
 jest.mock('@/contexts/auth', () => ({
     useAuth: jest.fn(),
-}));
-
-jest.mock('@/config/firebase', () => ({
-    callFunction: jest.fn(),
 }));
 
 jest.mock('react-native/Libraries/Settings/Settings', () => ({
@@ -57,29 +61,11 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
     removeItem: jest.fn(),
 }));
 
-
-
-// Mock the RouteHeader component if it's using Stack.Screen
-jest.mock('@/components/core/header/RouteHeader', () => {
-    const MockRouteHeader: FC<{ children: ReactNode; }> = ({ children }) => <>{children}</>;
-    return MockRouteHeader;
-});
-
-
-jest.mock('@/hooks/firebase/firestore', () => ({
-    usePrefetchedDynamicDoc: jest.fn(),
-}));
-
 jest.mock('@/config/firebase', () => ({
     CollectionOf: jest.fn(),
     getDownloadURL: jest.fn(),
-}));
-
-jest.mock('@/config/firebase', () => ({
     callFunction: jest.fn()
 }));
-
-
 
 // Mock react-native-blob-util to prevent NativeEventEmitter errors
 jest.mock('react-native-blob-util', () => ({
@@ -103,15 +89,10 @@ jest.mock('@react-native-firebase/messaging', () => ({
     })),
 }));
 
-
-
-
 // Mock react-native-pdf to prevent native calls
 jest.mock('react-native-pdf', () => {
     return () => <div data-testid="mock-pdf-viewer">PDF Viewer Mock</div>;
 });
-
-
 
 // Updated mock for expo-screen-orientation
 jest.mock('expo-screen-orientation', () => ({
@@ -127,9 +108,10 @@ jest.mock('expo-screen-orientation', () => ({
     removeOrientationChangeListener: jest.fn(),
 }));
 
+/* THIS IS THE PROBLEM
 jest.mock('react-native', () => ({
     Vibration: { vibrate: jest.fn() }
-}));
+}));*/
 
 jest.mock('@react-native-voice/voice', () => ({
     start: jest.fn(),
@@ -138,29 +120,36 @@ jest.mock('@react-native-voice/voice', () => ({
     onSpeechError: jest.fn(),
 }));
 
-
-jest.mock('expo-router', () => ({
-    useLocalSearchParams: jest.fn(),
-}));
-
-jest.mock('@/hooks/firebase/firestore', () => ({
-    usePrefetchedDynamicDoc: jest.fn(),
-}));
-
-
 // Mocked data and utility functions
 const mockLectureData = {
-    nbOfPages: 5,
-    data: { nbOfPages: 5 }
-};
+    data: {
+        nbOfPages: 5,
+    },
+}
 const mockParams = { courseNameString: 'testCourse', lectureIdString: 'testLectureId' };
 
+jest.mock('@/hooks/firebase/firestore', () => ({
+    usePrefetchedDynamicDoc: jest.fn(),  // Note the double array to match [lectureDoc]
+}));
 
-// AbstractEditor for to dos
+// We need this
+jest.mock('expo-modules-core', () => ({
+    NativeModulesProxy: {},
+    // Mock any other functions from expo-modules-core if needed
+}));
+
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    return {
+        Ionicons: (props: React.ComponentProps<'div'>) => React.createElement('div', props),
+    };
+});
+
+// Mock the AbstractRmtCtl component
 jest.mock('@/components/lectures/remotecontrol/abstractRmtCtl', () => {
     const TView = require('@/components/core/containers/TView').default;
     return {
-        AbstractRmtCtl: () => <TView testID="abstract-rmt-ctl" />,
+        AbstractRmtCrl: () => <TView testID="abstract-rmt-ctl" />,
     };
 });
 
@@ -170,36 +159,10 @@ jest.mock('@/components/lectures/remotecontrol/abstractRmtCtl', () => {
 // ------------------------------------------------------------
 
 
-
-import Voice from '@react-native-voice/voice';
-import { act } from '@testing-library/react-native';
-import * as ScreenOrientation from 'expo-screen-orientation';
-import React from 'react';
-
-
-// AbstractEditor for to dos
-jest.mock('@/components/lectures/remotecontrol/abstractRmtCtl', () => {
-    const TView = require('@/components/core/containers/TView').default;
-    return {
-        AbstractRmtCrl: () => <TView testID="abstract-rmt-crl" />,
-    };
-});
-
-// Mock dependencies
-jest.mock('@react-native-voice/voice', () => ({
-    start: jest.fn(),
-    stop: jest.fn(),
-}));
-
-jest.mock('expo-screen-orientation', () => ({
-    lockAsync: jest.fn(),
-}));
-
 describe('RemoteControlScreen Test Suite', () => {
     beforeEach(() => {
         jest.clearAllMocks();
     });
-
 
     it('calls startRecording to begin voice recording', async () => {
         await act(async () => {
@@ -225,10 +188,10 @@ describe('RemoteControlScreen Test Suite', () => {
         expect(ScreenOrientation.lockAsync).toHaveBeenCalledWith(ScreenOrientation.OrientationLock.PORTRAIT_UP);
     });
 
-
-    // it('renders the AbstractRmtCrl component', () => {
-    //     const { getByTestId } = render(<RemoteControlScreen />);
-
-    //     expect(getByTestId('abstract-rmt-crl')).toBeTruthy();
-    // });
+    it('renders the RemoteControlScreen component', () => {
+        (usePrefetchedDynamicDoc as jest.Mock).mockReturnValue([mockLectureData]);
+        const { getByTestId } = render(<RemoteControlScreen />);
+        //renderer.debug();
+        expect(getByTestId('abstract-rmt-ctl')).toBeTruthy();
+    });
 });

--- a/edweiss-app/app/(app)/lectures/remotecontrol/index.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/index.tsx
@@ -33,7 +33,7 @@ const RemoteControlScreen: ApplicationRoute = () => {
     const { courseNameString, lectureIdString } = useLocalSearchParams();
     const courseName = courseNameString as string;
     const lectureId = lectureIdString as string;
-    const [lectureDoc] = usePrefetchedDynamicDoc(CollectionOf<Lecture>(`courses/${courseName}/lectures`), lectureId, undefined);
+    const [lectureDoc] = usePrefetchedDynamicDoc(CollectionOf<Lecture>(`courses/${courseName}/lectures`), lectureId, undefined) || [];
     const [isRecording, setIsRecording] = useState<boolean>(false);
     const [currentPage, setCurrentPage] = useState<number>(1);
     const [pageToTranscribe, setPageToTranscribe] = useState<number>(1);
@@ -53,12 +53,14 @@ const RemoteControlScreen: ApplicationRoute = () => {
     Voice.onSpeechResults = (res) => { setTalked(res.value ? res.value[0] : ""); };
 
     return (
-        <AbstractRmtCrl
-            handleRight={() => handleRight(isRecording, currentPage, totalPages, setIsRecording, setCurrentPage, stopRecording)}
-            handleLeft={() => handleLeft(isRecording, currentPage, setIsRecording, setCurrentPage, stopRecording)}
-            handleMic={() => handleMic(isRecording, setIsRecording, startRecording, stopRecording)}
-            isRecording={isRecording}
-        />
+        <>
+            {<AbstractRmtCrl
+                handleRight={() => handleRight(isRecording, currentPage, totalPages, setIsRecording, setCurrentPage, stopRecording)}
+                handleLeft={() => handleLeft(isRecording, currentPage, setIsRecording, setCurrentPage, stopRecording)}
+                handleMic={() => handleMic(isRecording, setIsRecording, startRecording, stopRecording)}
+                isRecording={isRecording}
+            />}
+        </>
     );
 };
 


### PR DESCRIPTION
### **Problem:**
- Encountered the error: "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined." 
- The issue stemmed from incorrect or missing imports for components, which caused the React Native Testing Library to fail.

### **How I Fixed It:**
1. Initially, I used ChatGPT for quick suggestions, but all of them had already been addressed by the existing tests.
2. After about 2 hours of troubleshooting, I discovered the issue might be caused by the `RemoteControlScreen` being undefined, despite being correctly imported.
3. I examined the `RemoteControlScreen` component in `(app)/lectures/remotecontrol/index.tsx`. It rendered correctly on the phone but not in the test environment.
4. I simplified the component by commenting out the code, leaving only a basic display, and reran the test—still no success.
5. I then created a new, minimal test, mocking each dependency one by one. Eventually, I identified that an old, unused mock (`jest.mock('react-native', () => ({ Vibration: { vibrate: jest.fn() } }));`) was breaking the test. Considering the functionality of RemoteControlScreen, it is not necessary to have a mock for vibration. Thus I safely deleted it.
6. After removing this mock, the screen rendered correctly in the test. 
7. Finally, I mocked the necessary data and components that the `RemoteControlScreen` depends on to finalize the test.

### **Changes:**
- **Fixed the undefined component issue** by removing the problematic mock.
- **Refactored the test** by cleaning up duplicated mocks and simplifying the test setup.

### **Testing:**
- The test now runs successfully without errors, and the screen renders as expected.

- Verified that all mocks are correctly set up, and the screen behaves as expected in the test.
**Coverage**

| File Name   |Line Coverage (%) | 
|----------------|:-----------------:|
| `(app)/lectures/remotecontrol/index.tsx` | 85.29 %               |


Fixed #36 