### PR TITLE
The `Repository` - New way of handling collections and Cloud synchronization with optimistic updates.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,4 +19,7 @@
 	"javascript.preferences.quoteStyle": "single",
 	// "javascript.format.semicolons": "insert",
 	"javascript.format.insertSpaceAfterSemicolonInForStatements": true,
+	"files.watcherExclude": {
+		"**/target": true
+	},
 }

--- a/edweiss-app/__test__/__mocks__/common.d.ts
+++ b/edweiss-app/__test__/__mocks__/common.d.ts
@@ -1,0 +1,10 @@
+
+export interface Document<Type> {
+	id: string,
+	data: Type
+}
+
+export interface RepositoryDocument<Type> extends Document<Type> {
+	syncedId: boolean,
+	readonly fakeId?: string
+}

--- a/edweiss-app/__test__/__mocks__/core.tsx
+++ b/edweiss-app/__test__/__mocks__/core.tsx
@@ -1,0 +1,38 @@
+
+export namespace CoreMock {
+
+	export function mockTView() {
+		return jest.mock('@/components/core/containers/TView.tsx', () => {
+			const { View } = require('react-native');
+			return (props: any) => <View {...props} />;
+		});
+	}
+
+	export function mockTTouchableOpacity() {
+		return jest.mock('@/components/core/containers/TTouchableOpacity.tsx', () => {
+			const { TouchableOpacity, View } = require('react-native');
+			return (props: React.PropsWithChildren<any>) => (
+				<TouchableOpacity {...props}>
+					<View>{props.children}</View>
+				</TouchableOpacity>
+			);
+		});
+	}
+
+	export function mockTScrollView() {
+		return jest.mock('@/components/core/containers/TScrollView.tsx', () => {
+			const { ScrollView } = require('react-native');
+			return (props: any) => (
+				<ScrollView {...props} />
+			)
+		});
+	}
+
+	export function mockRouteHeader() {
+		return jest.mock('@/components/core/header/RouteHeader', () => {
+			const { Text } = require('react-native');
+			return ({ title }: { title: string }) => <Text>{title}</Text>;
+		});
+	}
+
+}

--- a/edweiss-app/__test__/__mocks__/index.tsx
+++ b/edweiss-app/__test__/__mocks__/index.tsx
@@ -1,0 +1,29 @@
+
+/**
+ * To refactor because those aren't working, we'll see.
+ */
+
+export namespace CommonMock {
+
+	// export function mockAsyncStorage(disk?: any) {
+	// 	return jest.mock('@react-native-async-storage/async-storage', () => ({
+	// 		// __esModule: true,
+	// 		setItem: jest.fn(),
+	// 		getItem: jest.fn(),
+	// 		removeItem: jest.fn(),
+	// 		getAllKeys: jest.fn(() => Promise.resolve(Object.keys(disk))),
+	// 		multiGet: jest.fn((keys) => Promise.resolve(keys.map((key: string) => disk[key]))),
+	// 		multiSet: jest.fn(() => Promise.resolve()),
+	// 		multiRemove: jest.fn(() => Promise.resolve())
+	// 	}));
+	// }
+
+	// export function mockExpoRouter(args: { params: any }) {
+	// 	return jest.mock('expo-router', () => ({
+	// 		...jest.requireActual('expo-router'),
+	// 		router: { push: jest.fn(), back: jest.fn() },
+	// 		useLocalSearchParams: jest.fn(() => args.params),
+	// 	}));
+	// }
+
+}

--- a/edweiss-app/__test__/__mocks__/repository.tsx
+++ b/edweiss-app/__test__/__mocks__/repository.tsx
@@ -1,0 +1,31 @@
+import { RepositoryDocument } from './common';
+
+export namespace RepositoryMock {
+
+	export function mockRepository<T>(documentsData: T[]) {
+		const docs: RepositoryDocument<T>[] = documentsData.map((data, index) => ({
+			data,
+			id: `${index + 1}`,
+			syncedId: true
+		}));
+
+		return jest.mock('@/hooks/repository', () => ({
+			...jest.requireActual('@/hooks/repository'),
+			useRepository: jest.fn(() => [
+				docs, {
+					addDocument: () => jest.fn(),
+					modifyDocument: () => jest.fn(),
+					deleteDocument: () => jest.fn(),
+					deleteDocuments: () => jest.fn(),
+				}]),
+			useRepositoryDocument: jest.fn(() => [
+				docs[0], {
+					addDocument: () => jest.fn(),
+					modifyDocument: () => jest.fn(),
+					deleteDocument: () => jest.fn(),
+					deleteDocuments: () => jest.fn(),
+				}]),
+		}));
+	}
+
+}

--- a/edweiss-app/__test__/__mocks__/repository.tsx
+++ b/edweiss-app/__test__/__mocks__/repository.tsx
@@ -13,19 +13,20 @@ export namespace RepositoryMock {
 			...jest.requireActual('@/hooks/repository'),
 			useRepository: jest.fn(() => [
 				docs, {
-					addDocument: () => jest.fn(),
-					modifyDocument: () => jest.fn(),
-					deleteDocument: () => jest.fn(),
-					deleteDocuments: () => jest.fn(),
-				}]),
-			useRepositoryDocument: jest.fn(() => [
-				docs[0], {
-					addDocument: () => jest.fn(),
-					modifyDocument: () => jest.fn(),
-					deleteDocument: () => jest.fn(),
-					deleteDocuments: () => jest.fn(),
-				}]),
+					addDocument: jest.fn(),
+					modifyDocument: jest.fn(),
+					deleteDocument: jest.fn(),
+					deleteDocuments: jest.fn(),
+				}
+			]),
+			useRepositoryDocument: jest.fn((id: string) => [
+				docs.find(doc => doc.id === id) || null, {
+					addDocument: jest.fn(),
+					modifyDocument: jest.fn(),
+					deleteDocument: jest.fn(),
+					deleteDocuments: jest.fn(),
+				}
+			]),
 		}));
 	}
-
 }

--- a/edweiss-app/__test__/memento/card.test.tsx
+++ b/edweiss-app/__test__/memento/card.test.tsx
@@ -22,6 +22,7 @@ import { router } from 'expo-router';
 import React from 'react';
 import { Button } from 'react-native';
 import { State } from 'react-native-gesture-handler';
+import { RepositoryMock } from '../__mocks__/repository';
 
 // ------------------------------------------------------------
 // ---------------------  Mock Data & Setup -------------------
@@ -29,59 +30,87 @@ import { State } from 'react-native-gesture-handler';
 
 // Mock cards
 const card1: Memento.Card = {
-    question: 'Question 1',
-    answer: 'Answer 1',
-    learning_status: 'Got it',
+	question: 'Question 1',
+	answer: 'Answer 1',
+	learning_status: 'Got it',
 };
 
 const card2: Memento.Card = {
-    question: 'Question 2',
-    answer: 'Answer 2',
-    learning_status: 'Not yet',
+	question: 'Question 2',
+	answer: 'Answer 2',
+	learning_status: 'Not yet',
 };
 
 // Mock AsyncStorage
 jest.mock('@react-native-async-storage/async-storage', () => ({
-    setItem: jest.fn(),
-    getItem: jest.fn(),
-    removeItem: jest.fn(),
+	setItem: jest.fn(),
+	getItem: jest.fn(),
+	removeItem: jest.fn(),
+	getAllKeys: jest.fn(() => Promise.resolve([])),
+	multiGet: jest.fn((keys) => Promise.resolve(keys.map((key: string) => [key, 'value']))),
+	multiSet: jest.fn(() => Promise.resolve()),
+	multiRemove: jest.fn(() => Promise.resolve()),
 }));
+// CommonMock.mockAsyncStorage();
 
 // Mock Firebase functions and firestore
 jest.mock('@/config/firebase', () => ({
-    callFunction: jest.fn(),
-    Collections: { deck: 'decks' }
+	callFunction: jest.fn(),
+	Collections: { deck: 'decks' }
 }));
 
 jest.mock('@/hooks/firebase/firestore', () => ({
-    useDynamicDocs: jest.fn(() => [
-        { id: '1', data: { name: 'Deck 1', cards: [card1, card2] } }
-    ]),
-    useDoc: jest.fn(() => ({ data: { cards: [card1, card2] } })),
+	useDynamicDocs: jest.fn(() => [
+		{ id: '1', data: { name: 'Deck 1', cards: [card1, card2] } }
+	]),
+	useDoc: jest.fn(() => ({ data: { cards: [card1, card2] } })),
 }));
+
+// jest.mock('@/hooks/repository', () => ({
+// 	useRepository: jest.fn(() => [
+// 		[{ id: '1', data: { name: 'Deck 1', cards: [card1, card2] } }]
+// 		, {
+// 			addDocument: () => jest.fn(),
+// 			modifyDocument: () => jest.fn(),
+// 			deleteDocument: () => jest.fn(),
+// 			deleteDocuments: () => jest.fn(),
+// 		}]),
+// 	useRepositoryDocument: jest.fn(() => [
+// 		{ id: '1', data: { name: 'Deck 1', cards: [card1, card2] } }
+// 		, {
+// 			addDocument: () => jest.fn(),
+// 			modifyDocument: () => jest.fn(),
+// 			deleteDocument: () => jest.fn(),
+// 			deleteDocuments: () => jest.fn(),
+// 		}]),
+// }));
+// CommonMock.mockAsyncStorage();
+RepositoryMock.mockRepository<Memento.Deck>([{ name: 'Deck 1', cards: [card1, card2] }]);
+// CoreMock.mockRouteHeader();
+// CommonMock.mockExpoRouter({ params: { id: '1' } });
 
 // Mock expo-router Stack and Screen
 jest.mock('expo-router', () => ({
-    router: { push: jest.fn(), back: jest.fn() },
-    Stack: {
-        Screen: jest.fn(({ options }) => (
-            <>{options.headerRight()}, {options.headerLeft()}
-            </>  // Render the right prop directly for testing
-        )),
-    },
-    //useLocalSearchParams: jest.fn(),
-    useLocalSearchParams: jest.fn(() => ({ id: '1' })),
+	router: { push: jest.fn(), back: jest.fn() },
+	Stack: {
+		Screen: jest.fn(({ options }) => (
+			<>{options.headerRight()}, {options.headerLeft()}
+			</>  // Render the right prop directly for testing
+		)),
+	},
+	//useLocalSearchParams: jest.fn(),
+	useLocalSearchParams: jest.fn(() => ({ id: '1' })),
 }));
 
 // Mock BottomSheet modal
 jest.mock('@gorhom/bottom-sheet', () => ({
-    BottomSheetModal: jest.fn(({ children }) => (
-        <div>{children}</div> // Simple mock
-    )),
-    BottomSheetView: jest.fn(({ children }) => (
-        <div>{children}</div> // Simple mock
-    )),
-    BottomSheetBackdrop: jest.fn(),
+	BottomSheetModal: jest.fn(({ children }) => (
+		<div>{children}</div> // Simple mock
+	)),
+	BottomSheetView: jest.fn(({ children }) => (
+		<div>{children}</div> // Simple mock
+	)),
+	BottomSheetBackdrop: jest.fn(),
 }));
 
 // Mock reanimated library
@@ -96,485 +125,485 @@ const toggleFlip = jest.fn(); // This function is not exported, so we mock it he
 
 // Test suite for the CardListScreen component
 describe('CardListScreen', () => {
-    beforeEach(() => {
-        jest.clearAllMocks(); // Clear previous mocks before each test
-    });
+	beforeEach(() => {
+		jest.clearAllMocks(); // Clear previous mocks before each test
+	});
 
-    it('renders without crashing', () => {
-        const { getByText } = render(<CardListScreen />);
-        expect(getByText('Question 1')).toBeTruthy();
-        expect(getByText('Question 2')).toBeTruthy();
-        expect(getByText('Got it')).toBeTruthy();
-        expect(getByText('Not yet')).toBeTruthy();
-    });
+	it('renders without crashing', () => {
+		const { getByText } = render(<CardListScreen />);
+		expect(getByText('Question 1')).toBeTruthy();
+		expect(getByText('Question 2')).toBeTruthy();
+		expect(getByText('Got it')).toBeTruthy();
+		expect(getByText('Not yet')).toBeTruthy();
+	});
 
-    it('toggles card selection', () => {
-        const { getByText } = render(<CardListScreen />);
-        const question1 = getByText('Question 1');
-        const question2 = getByText('Question 2');
+	it('toggles card selection', () => {
+		const { getByText } = render(<CardListScreen />);
+		const question1 = getByText('Question 1');
+		const question2 = getByText('Question 2');
 
-        fireEvent(question1, 'onLongPress');
-        expect(getByText('Question 1')).toBeTruthy();
+		fireEvent(question1, 'onLongPress');
+		expect(getByText('Question 1')).toBeTruthy();
 
-        fireEvent(question2, 'onLongPress');
-        expect(getByText('Question 2')).toBeTruthy();
-    });
+		fireEvent(question2, 'onLongPress');
+		expect(getByText('Question 2')).toBeTruthy();
+	});
 
-    it('can delete selected cards', async () => {
-        const { getByText } = render(<CardListScreen />);
-        const card2 = getByText('Question 2');
+	it('can delete selected cards', async () => {
+		const { getByText } = render(<CardListScreen />);
+		const card2 = getByText('Question 2');
 
-        // Simulate long press to select the card
-        fireEvent(card2, 'onLongPress');
+		// Simulate long press to select the card
+		fireEvent(card2, 'onLongPress');
 
-        // Simulate clicking the delete button
-        const deleteButton = getByText('Delete Selected Cards');
-        fireEvent.press(deleteButton);
+		// Simulate clicking the delete button
+		const deleteButton = getByText('Delete Selected Cards');
+		fireEvent.press(deleteButton);
 
-        expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteCards, { deckId: '1', cardIndices: [1] });
-    });
+		expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteCards, { deckId: '1', cardIndices: [1] });
+	});
 
-    it('can cancel card selection', () => {
-        const { getByText } = render(<CardListScreen />);
-        const card2 = getByText('Question 2');
+	it('can cancel card selection', () => {
+		const { getByText } = render(<CardListScreen />);
+		const card2 = getByText('Question 2');
 
-        // Simulate long press to select the card
-        fireEvent(card2, 'onLongPress');
+		// Simulate long press to select the card
+		fireEvent(card2, 'onLongPress');
 
-        // Simulate clicking the cancel button
-        const cancelButton = getByText('Cancel');
-        fireEvent.press(cancelButton);
+		// Simulate clicking the cancel button
+		const cancelButton = getByText('Cancel');
+		fireEvent.press(cancelButton);
 
-        expect(getByText('Question 2')).toBeTruthy();
-    });
+		expect(getByText('Question 2')).toBeTruthy();
+	});
 
-    it('can go to playing screen', () => {
-        const { getByTestId } = render(<CardListScreen />);
-        const playButton = getByTestId('playButton');
+	it('can go to playing screen', () => {
+		const { getByTestId } = render(<CardListScreen />);
+		const playButton = getByTestId('playButton');
 
-        fireEvent.press(playButton);
-        expect(router.push).toHaveBeenCalledWith({ pathname: "deck/1/playingCards" });
-    });
+		fireEvent.press(playButton);
+		expect(router.push).toHaveBeenCalledWith({ pathname: "deck/1/playingCards" });
+	});
 
-    it('can create a new card', () => {
-        const { getByText } = render(<CardListScreen />);
-        const createButton = getByText('Create Card');
+	it('can create a new card', () => {
+		const { getByText } = render(<CardListScreen />);
+		const createButton = getByText('Create Card');
 
-        fireEvent.press(createButton);
-        expect(router.push).toHaveBeenCalledWith({ pathname: "/deck/1/card/creation", params: { deckId: '1' } });
-    });
+		fireEvent.press(createButton);
+		expect(router.push).toHaveBeenCalledWith({ pathname: "/deck/1/card/creation", params: { deckId: '1' } });
+	});
 
-    it('can delete a deck', () => {
-        const { getByTestId, queryByTestId } = render(<CardListScreen />);
-        // Initially, the dropdown should not be visible
-        expect(queryByTestId('dropDownContent')).toBeNull();
+	it('can delete a deck', () => {
+		const { getByTestId, queryByTestId } = render(<CardListScreen />);
+		// Initially, the dropdown should not be visible
+		expect(queryByTestId('dropDownContent')).toBeNull();
 
-        // Press the button to show the dropdown
-        const toggleButton = getByTestId('toggleButton');
-        fireEvent.press(toggleButton);
+		// Press the button to show the dropdown
+		const toggleButton = getByTestId('toggleButton');
+		fireEvent.press(toggleButton);
 
-        // Now, the dropdown should be visible
-        expect(getByTestId('dropDownContent')).toBeTruthy();
+		// Now, the dropdown should be visible
+		expect(getByTestId('dropDownContent')).toBeTruthy();
 
-        // Press the button again to hide the dropdown
-        fireEvent.press(toggleButton);
+		// Press the button again to hide the dropdown
+		fireEvent.press(toggleButton);
 
-        // The dropdown should be hidden again
-        expect(queryByTestId('dropDownContent')).toBeNull();
+		// The dropdown should be hidden again
+		expect(queryByTestId('dropDownContent')).toBeNull();
 
-        // Press the button again to show the dropdown
-        fireEvent.press(toggleButton);
+		// Press the button again to show the dropdown
+		fireEvent.press(toggleButton);
 
-        const deleteDeckButton = getByTestId('deleteDeckButton');
-        expect(deleteDeckButton).toBeTruthy();
+		const deleteDeckButton = getByTestId('deleteDeckButton');
+		expect(deleteDeckButton).toBeTruthy();
 
-        // Press the delete deck button
-        fireEvent.press(deleteDeckButton);
+		// Press the delete deck button
+		fireEvent.press(deleteDeckButton);
 
-    });
+	});
 
-    it('cards are sorted according to learning status', () => {
-        const sortedCards = sortingCards([card1, card2]);
-        expect(sortedCards[0].question).toBe('Question 2');
-        expect(sortedCards[1].question).toBe('Question 1');
-    });
+	it('cards are sorted according to learning status', () => {
+		const sortedCards = sortingCards([card1, card2]);
+		expect(sortedCards[0].question).toBe('Question 2');
+		expect(sortedCards[1].question).toBe('Question 1');
+	});
 
 });
 
 // Test suite for the utility functions
 describe('handlePress', () => {
-    const mockCard: Memento.Card = {
-        question: 'Test Question',
-        answer: 'Test Answer',
-        learning_status: 'Got it',
-    };
+	const mockCard: Memento.Card = {
+		question: 'Test Question',
+		answer: 'Test Answer',
+		learning_status: 'Got it',
+	};
 
-    const mockGoToPath = jest.fn();
-    const mockToggleSelection = jest.fn();
+	const mockGoToPath = jest.fn();
+	const mockToggleSelection = jest.fn();
 
-    beforeEach(() => {
-        jest.clearAllMocks(); // Clear previous mocks before each test
-    });
+	beforeEach(() => {
+		jest.clearAllMocks(); // Clear previous mocks before each test
+	});
 
-    it('calls goToPath when not in selection mode', () => {
-        handlePress(mockCard, false, mockGoToPath, mockToggleSelection);
+	it('calls goToPath when not in selection mode', () => {
+		handlePress(mockCard, false, mockGoToPath, mockToggleSelection);
 
-        expect(mockGoToPath).toHaveBeenCalled();
-        expect(mockToggleSelection).not.toHaveBeenCalled(); // Ensure toggleSelection is not called
-    });
+		expect(mockGoToPath).toHaveBeenCalled();
+		expect(mockToggleSelection).not.toHaveBeenCalled(); // Ensure toggleSelection is not called
+	});
 
-    it('calls toggleSelection when in selection mode', () => {
-        handlePress(mockCard, true, mockGoToPath, mockToggleSelection);
+	it('calls toggleSelection when in selection mode', () => {
+		handlePress(mockCard, true, mockGoToPath, mockToggleSelection);
 
-        expect(mockToggleSelection).toHaveBeenCalledWith(mockCard);
-        expect(mockGoToPath).not.toHaveBeenCalled(); // Ensure goToPath is not called
-    });
+		expect(mockToggleSelection).toHaveBeenCalledWith(mockCard);
+		expect(mockGoToPath).not.toHaveBeenCalled(); // Ensure goToPath is not called
+	});
 
-    // Add additional tests for edge cases if necessary
+	// Add additional tests for edge cases if necessary
 });
 
 
 describe('handleCardPress', () => {
-    let modalRef: React.RefObject<BottomSheetModal>;
-    let setSelectedCardIndex: jest.Mock;
+	let modalRef: React.RefObject<BottomSheetModal>;
+	let setSelectedCardIndex: jest.Mock;
 
-    beforeEach(() => {
-        // Create a mock for modalRef
-        modalRef = {
-            current: {
-                present: jest.fn(),
-                dismiss: jest.fn(),
-                snapToIndex: jest.fn(),
-                snapToPosition: jest.fn(),
-                expand: jest.fn(),
-                collapse: jest.fn(),
-                close: jest.fn(),
-                forceClose: jest.fn(),
-            },
-        };
+	beforeEach(() => {
+		// Create a mock for modalRef
+		modalRef = {
+			current: {
+				present: jest.fn(),
+				dismiss: jest.fn(),
+				snapToIndex: jest.fn(),
+				snapToPosition: jest.fn(),
+				expand: jest.fn(),
+				collapse: jest.fn(),
+				close: jest.fn(),
+				forceClose: jest.fn(),
+			},
+		};
 
-        setSelectedCardIndex = jest.fn();
-    });
+		setSelectedCardIndex = jest.fn();
+	});
 
-    it('opens modal when a card is pressed and no card is selected', () => {
-        // Call handleCardPress with the appropriate arguments
-        handleCardPress(0, false, null, setSelectedCardIndex, modalRef);
+	it('opens modal when a card is pressed and no card is selected', () => {
+		// Call handleCardPress with the appropriate arguments
+		handleCardPress(0, false, null, setSelectedCardIndex, modalRef);
 
-        expect(setSelectedCardIndex).toHaveBeenCalledWith(0);
-        expect(modalRef.current?.present).toHaveBeenCalled();
-    });
+		expect(setSelectedCardIndex).toHaveBeenCalledWith(0);
+		expect(modalRef.current?.present).toHaveBeenCalled();
+	});
 
-    it('closes modal when the same card is pressed', () => {
-        // Call handleCardPress to select a card
-        handleCardPress(0, false, 0, setSelectedCardIndex, modalRef);
+	it('closes modal when the same card is pressed', () => {
+		// Call handleCardPress to select a card
+		handleCardPress(0, false, 0, setSelectedCardIndex, modalRef);
 
-        expect(modalRef.current?.dismiss).toHaveBeenCalled();
-        expect(setSelectedCardIndex).toHaveBeenCalledWith(null);
-    });
+		expect(modalRef.current?.dismiss).toHaveBeenCalled();
+		expect(setSelectedCardIndex).toHaveBeenCalledWith(null);
+	});
 
-    // Additional test cases can be added here to cover more scenarios
+	// Additional test cases can be added here to cover more scenarios
 });
 
 
 describe('RouteHeader', () => {
-    it('renders the right and left prop button', () => {
-        const { getByTestId } = render(
-            <RouteHeader
-                title="Test Header"
-                left={<Button testID="leftButton" onPress={jest.fn()} title="Left" />}
-                right={<Button testID="toggleButton" onPress={jest.fn()} title="Toggle" />}
-            />
-        );
+	it('renders the right and left prop button', () => {
+		const { getByTestId } = render(
+			<RouteHeader
+				title="Test Header"
+				left={<Button testID="leftButton" onPress={jest.fn()} title="Left" />}
+				right={<Button testID="toggleButton" onPress={jest.fn()} title="Toggle" />}
+			/>
+		);
 
-        // Expect the button to be in the document
-        expect(getByTestId('toggleButton')).toBeTruthy();
-        expect(getByTestId('leftButton')).toBeTruthy();
-    });
+		// Expect the button to be in the document
+		expect(getByTestId('toggleButton')).toBeTruthy();
+		expect(getByTestId('leftButton')).toBeTruthy();
+	});
 });
 
 // Test suite for the TestYourMightScreen component
 describe('TestYourMightScreen', () => {
-    it('should render correctly', () => {
-        const { getByText } = render(<TestYourMightScreen />);
-        expect(getByText('1/2')).toBeTruthy();
-    });
+	it('should render correctly', () => {
+		const { getByText } = render(<TestYourMightScreen />);
+		expect(getByText('1/2')).toBeTruthy();
+	});
 
-    it('should increment currentCardIndex on left swipe', () => {
-        const { getByTestId, getByText } = render(<TestYourMightScreen />);
-        const panGesture = getByTestId('pan-gesture');
+	it('should increment currentCardIndex on left swipe', () => {
+		const { getByTestId, getByText } = render(<TestYourMightScreen />);
+		const panGesture = getByTestId('pan-gesture');
 
-        if (panGesture) {
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.END, translationX: -100 },
-            });
-            expect(getByText('2/2')).toBeTruthy();
-        }
-    });
+		if (panGesture) {
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.END, translationX: -100 },
+			});
+			expect(getByText('2/2')).toBeTruthy();
+		}
+	});
 
-    it('should decrement currentCardIndex on right swipe', () => {
-        const { getByTestId, getByText } = render(<TestYourMightScreen />);
-        const panGesture = getByTestId('pan-gesture');
+	it('should decrement currentCardIndex on right swipe', () => {
+		const { getByTestId, getByText } = render(<TestYourMightScreen />);
+		const panGesture = getByTestId('pan-gesture');
 
-        if (panGesture) {
-            // First, swipe left to go to the second card
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.END, translationX: -100 },
-            });
-            expect(getByText('2/2')).toBeTruthy();
+		if (panGesture) {
+			// First, swipe left to go to the second card
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.END, translationX: -100 },
+			});
+			expect(getByText('2/2')).toBeTruthy();
 
-            // Then swipe right to go back to the first card
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.END, translationX: 100 },
-            });
-            expect(getByText('1/2')).toBeTruthy();
-        }
-    });
+			// Then swipe right to go back to the first card
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.END, translationX: 100 },
+			});
+			expect(getByText('1/2')).toBeTruthy();
+		}
+	});
 
-    it('should not go out of bounds', () => {
-        const { getByTestId, getByText } = render(<TestYourMightScreen />);
-        const panGesture = getByTestId('pan-gesture');
+	it('should not go out of bounds', () => {
+		const { getByTestId, getByText } = render(<TestYourMightScreen />);
+		const panGesture = getByTestId('pan-gesture');
 
-        if (panGesture) {
-            // Attempt to swipe right on the first card (should stay at 1/2)
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.END, translationX: 100 },
-            });
-            expect(getByText('1/2')).toBeTruthy();
+		if (panGesture) {
+			// Attempt to swipe right on the first card (should stay at 1/2)
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.END, translationX: 100 },
+			});
+			expect(getByText('1/2')).toBeTruthy();
 
-            // Swipe to last card
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.END, translationX: -100 },
-            });
-            expect(getByText('2/2')).toBeTruthy();
+			// Swipe to last card
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.END, translationX: -100 },
+			});
+			expect(getByText('2/2')).toBeTruthy();
 
-            // Attempt to swipe left on the last card (should stay at 2/2)
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.END, translationX: -100 },
-            });
-            expect(getByText('2/2')).toBeTruthy();
-        }
-    });
+			// Attempt to swipe left on the last card (should stay at 2/2)
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.END, translationX: -100 },
+			});
+			expect(getByText('2/2')).toBeTruthy();
+		}
+	});
 
-    it('should do nothing if gesture state is not END', () => {
-        const { getByTestId, getByText } = render(<TestYourMightScreen />);
-        const panGesture = getByTestId('pan-gesture');
+	it('should do nothing if gesture state is not END', () => {
+		const { getByTestId, getByText } = render(<TestYourMightScreen />);
+		const panGesture = getByTestId('pan-gesture');
 
-        if (panGesture) {
-            // Try a left swipe with a state that isn't END
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.BEGAN, translationX: -100 },
-            });
+		if (panGesture) {
+			// Try a left swipe with a state that isn't END
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.BEGAN, translationX: -100 },
+			});
 
-            // Check that currentCardIndex hasn't incremented
-            expect(getByText('1/2')).toBeTruthy();
+			// Check that currentCardIndex hasn't incremented
+			expect(getByText('1/2')).toBeTruthy();
 
-            // Try a right swipe with a state that isn't END
-            fireEvent(panGesture, 'onHandlerStateChange', {
-                nativeEvent: { state: State.BEGAN, translationX: 100 },
-            });
+			// Try a right swipe with a state that isn't END
+			fireEvent(panGesture, 'onHandlerStateChange', {
+				nativeEvent: { state: State.BEGAN, translationX: 100 },
+			});
 
-            // Check again to confirm it hasn't decremented either
-            expect(getByText('1/2')).toBeTruthy();
-        }
-    });
+			// Check again to confirm it hasn't decremented either
+			expect(getByText('1/2')).toBeTruthy();
+		}
+	});
 });
 
 // Test suite for the CreateCardScreen component
 describe('CreateCardScreen', () => {
-    afterAll(() => {
-        jest.clearAllMocks();
-    });
+	afterAll(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should render correctly', () => {
-        const { getByText, getByTestId } = render(<CreateCardScreen />);
-        expect(getByText('Question')).toBeTruthy();
-        expect(getByText('Answer')).toBeTruthy();
-        expect(getByTestId('createCardButton')).toBeTruthy();
-    });
+	it('should render correctly', () => {
+		const { getByText, getByTestId } = render(<CreateCardScreen />);
+		expect(getByText('Question')).toBeTruthy();
+		expect(getByText('Answer')).toBeTruthy();
+		expect(getByTestId('createCardButton')).toBeTruthy();
+	});
 
-    it('should not create a card when the fields are not filled', async () => {
-        const { getByTestId } = render(<CreateCardScreen />);
-        const createButton = getByTestId('createCardButton');
+	it('should not create a card when the fields are not filled', async () => {
+		const { getByTestId } = render(<CreateCardScreen />);
+		const createButton = getByTestId('createCardButton');
 
-        fireEvent.press(createButton);
-        expect(router.back).not.toHaveBeenCalled();
-    });
+		fireEvent.press(createButton);
+		expect(router.back).not.toHaveBeenCalled();
+	});
 
-    it('should create a card when the fields are filled', async () => {
+	it('should create a card when the fields are filled', async () => {
 
-        const { getByTestId, getByText } = render(<CreateCardScreen />);
+		const { getByTestId, getByText } = render(<CreateCardScreen />);
 
-        // Mock successful response for creating a card
-        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: '1' } });
+		// Mock successful response for creating a card
+		(callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: '1' } });
 
-        fireEvent.changeText(getByText('Question'), 'Test Question');
-        fireEvent.changeText(getByText('Answer'), 'Test Answer');
+		fireEvent.changeText(getByText('Question'), 'Test Question');
+		fireEvent.changeText(getByText('Answer'), 'Test Answer');
 
-        const createButton = getByTestId('createCardButton');
+		const createButton = getByTestId('createCardButton');
 
-        fireEvent.press(createButton);
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.createCard, {
-                deckId: undefined,
-                card: {
-                    question: 'Test Question',
-                    answer: 'Test Answer',
-                    learning_status: 'Not yet',
-                } // Ensure callFunction was called with correct arguments
-            });
-        });
+		fireEvent.press(createButton);
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.createCard, {
+				deckId: undefined,
+				card: {
+					question: 'Test Question',
+					answer: 'Test Answer',
+					learning_status: 'Not yet',
+				} // Ensure callFunction was called with correct arguments
+			});
+		});
 
-        expect(router.back).toHaveBeenCalled();
-    });
+		expect(router.back).toHaveBeenCalled();
+	});
 
-    it('should not create a card when there is a duplicate question', async () => {
-        const { getByTestId, getByText } = render(<CreateCardScreen />);
+	it('should not create a card when there is a duplicate question', async () => {
+		const { getByTestId, getByText } = render(<CreateCardScreen />);
 
-        // Mock a duplicate question
-        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 0 });
+		// Mock a duplicate question
+		(callFunction as jest.Mock).mockResolvedValueOnce({ status: 0 });
 
-        fireEvent.changeText(getByText('Question'), 'Question 1');
-        fireEvent.changeText(getByText('Answer'), 'Answer 1');
+		fireEvent.changeText(getByText('Question'), 'Question 1');
+		fireEvent.changeText(getByText('Answer'), 'Answer 1');
 
-        const createButton = getByTestId('createCardButton');
+		const createButton = getByTestId('createCardButton');
 
-        fireEvent.press(createButton);
+		fireEvent.press(createButton);
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalled();
-            expect(getByText('Question already exists')).toBeTruthy();
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalled();
+			expect(getByText('Question already exists')).toBeTruthy();
+		});
+	});
 });
 
 // Test suite for the CardScreenComponent component
 describe('CardScreen', () => {
-    let modalRef: React.RefObject<BottomSheetModal>;
+	let modalRef: React.RefObject<BottomSheetModal>;
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should render correctly', () => {
-        const { getByText, getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
-        expect(getByText('Question 1')).toBeTruthy();
+	it('should render correctly', () => {
+		const { getByText, getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
+		expect(getByText('Question 1')).toBeTruthy();
 
-        const flipButton = getByTestId('flipCardToSeeAnswer')
-        fireEvent.press(flipButton);
+		const flipButton = getByTestId('flipCardToSeeAnswer')
+		fireEvent.press(flipButton);
 
-        expect(getByText('Answer 1')).toBeTruthy();
+		expect(getByText('Answer 1')).toBeTruthy();
 
-        const flipButton2 = getByTestId('flipCardToSeeQuestion')
-        fireEvent.press(flipButton2);
+		const flipButton2 = getByTestId('flipCardToSeeQuestion')
+		fireEvent.press(flipButton2);
 
-        expect(getByText('Question 1')).toBeTruthy();
-    });
+		expect(getByText('Question 1')).toBeTruthy();
+	});
 
-    it('should delete a card', async () => {
-        const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
+	it('should delete a card', async () => {
+		const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
 
-        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: '1' } });
+		(callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: '1' } });
 
-        const dropDown = getByTestId('toggleButton')
-        fireEvent.press(dropDown);
+		const dropDown = getByTestId('toggleButton')
+		fireEvent.press(dropDown);
 
-        const deleteButton = getByTestId('deleteCardButton');
-        fireEvent.press(deleteButton);
+		const deleteButton = getByTestId('deleteCardButton');
+		fireEvent.press(deleteButton);
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteCards, { deckId: '1', cardIndices: [0] });
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteCards, { deckId: '1', cardIndices: [0] });
+		});
+	});
 
-    it('should catch an error when deleting a card', async () => {
-        const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
+	it('should catch an error when deleting a card', async () => {
+		const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
 
-        (callFunction as jest.Mock).mockRejectedValueOnce('Error deleting card');
-        const dropDown = getByTestId('toggleButton')
-        fireEvent.press(dropDown);
+		(callFunction as jest.Mock).mockRejectedValueOnce('Error deleting card');
+		const dropDown = getByTestId('toggleButton')
+		fireEvent.press(dropDown);
 
-        const deleteButton = getByTestId('deleteCardButton');
-        fireEvent.press(deleteButton);
+		const deleteButton = getByTestId('deleteCardButton');
+		fireEvent.press(deleteButton);
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteCards, { deckId: '1', cardIndices: [0] });
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteCards, { deckId: '1', cardIndices: [0] });
+		});
+	});
 
-    it('should update a card when click on button to change learning status', async () => {
-        const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
+	it('should update a card when click on button to change learning status', async () => {
+		const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
 
-        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: '1' } });
+		(callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: '1' } });
 
-        const notYetButton = getByTestId('notYetButton')
-        fireEvent.press(notYetButton);
+		const notYetButton = getByTestId('notYetButton')
+		fireEvent.press(notYetButton);
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.updateCard, {
-                deckId: '1',
-                newCard: {
-                    question: 'Question 1',
-                    answer: 'Answer 1',
-                    learning_status: 'Not yet',
-                },
-                cardIndex: 0
-            });
-        });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.updateCard, {
+				deckId: '1',
+				newCard: {
+					question: 'Question 1',
+					answer: 'Answer 1',
+					learning_status: 'Not yet',
+				},
+				cardIndex: 0
+			});
+		});
 
-        const gotItButton = getByTestId('gotItButton')
-        fireEvent.press(gotItButton);
+		const gotItButton = getByTestId('gotItButton')
+		fireEvent.press(gotItButton);
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.updateCard, {
-                deckId: '1',
-                newCard: {
-                    question: 'Question 1',
-                    answer: 'Answer 1',
-                    learning_status: 'Got it',
-                },
-                cardIndex: 0
-            });
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.updateCard, {
+				deckId: '1',
+				newCard: {
+					question: 'Question 1',
+					answer: 'Answer 1',
+					learning_status: 'Got it',
+				},
+				cardIndex: 0
+			});
+		});
+	});
 
-    it('should go to edit card screen when click on button to edit card', () => {
-        const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
-        const dropDownButton = getByTestId('toggleButton');
-        fireEvent.press(dropDownButton);
+	it('should go to edit card screen when click on button to edit card', () => {
+		const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
+		const dropDownButton = getByTestId('toggleButton');
+		fireEvent.press(dropDownButton);
 
-        const editButton = getByTestId('editCardButton');
+		const editButton = getByTestId('editCardButton');
 
-        fireEvent.press(editButton);
-        expect(router.push).toHaveBeenCalledWith({ pathname: "/deck/1/card/edition", params: { deckId: '1', prev_question: 'Question 1', prev_answer: 'Answer 1', cardIndex: 0 } });
-    });
+		fireEvent.press(editButton);
+		expect(router.push).toHaveBeenCalledWith({ pathname: "/deck/1/card/edition", params: { deckId: '1', prev_question: 'Question 1', prev_answer: 'Answer 1', cardIndex: 0 } });
+	});
 
-    it('should call toggleFlip on question tap', () => {
-        const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
+	it('should call toggleFlip on question tap', () => {
+		const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} modalRef={modalRef} />);
 
-        const flipCard = getByTestId('flipCardToSeeAnswer');
-        fireEvent(flipCard, 'onHandlerStateChange', { nativeEvent: { state: State.END } });
+		const flipCard = getByTestId('flipCardToSeeAnswer');
+		fireEvent(flipCard, 'onHandlerStateChange', { nativeEvent: { state: State.END } });
 
-        expect(toggleFlip).toHaveBeenCalledTimes(0);
+		expect(toggleFlip).toHaveBeenCalledTimes(0);
 
-        const flipCard2 = getByTestId('flipCardToSeeQuestion');
-        fireEvent(flipCard2, 'onHandlerStateChange', { nativeEvent: { state: State.END } });
+		const flipCard2 = getByTestId('flipCardToSeeQuestion');
+		fireEvent(flipCard2, 'onHandlerStateChange', { nativeEvent: { state: State.END } });
 
-        expect(toggleFlip).toHaveBeenCalledTimes(0);
+		expect(toggleFlip).toHaveBeenCalledTimes(0);
 
-        fireEvent(flipCard, 'onHandlerStateChange', { nativeEvent: { state: State.CANCELLED } });
+		fireEvent(flipCard, 'onHandlerStateChange', { nativeEvent: { state: State.CANCELLED } });
 
-        expect(toggleFlip).toHaveBeenCalledTimes(0);
+		expect(toggleFlip).toHaveBeenCalledTimes(0);
 
-        fireEvent(flipCard2, 'onHandlerStateChange', { nativeEvent: { state: State.CANCELLED } });
+		fireEvent(flipCard2, 'onHandlerStateChange', { nativeEvent: { state: State.CANCELLED } });
 
-        expect(toggleFlip).toHaveBeenCalledTimes(0);
-    });
+		expect(toggleFlip).toHaveBeenCalledTimes(0);
+	});
 
-    it('should display different styles if isModal is true', () => {
-        const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} isModal={true} modalRef={modalRef} />);
-        const flipCard = getByTestId('flipCardToSeeAnswer');
+	it('should display different styles if isModal is true', () => {
+		const { getByTestId } = render(<CardScreenComponent deckId="1" cardIndex={0} isModal={true} modalRef={modalRef} />);
+		const flipCard = getByTestId('flipCardToSeeAnswer');
 
-        expect(flipCard.props.style).toEqual(expect.arrayContaining([{ ...styles.modalCard }]));
-    });
+		expect(flipCard.props.style).toEqual(expect.arrayContaining([{ ...styles.modalCard }]));
+	});
 
 });

--- a/edweiss-app/__test__/memento/deck.test.tsx
+++ b/edweiss-app/__test__/memento/deck.test.tsx
@@ -15,6 +15,7 @@ import { router } from 'expo-router';
 import React from 'react';
 import 'react-native';
 import DeckScreen, { DeckDisplay } from '../../app/(app)/deck/index';
+import { RepositoryMock } from '../__mocks__/repository';
 
 // ------------------------------------------------------------
 // ---------------------  Mocks & Setups  ---------------------
@@ -22,31 +23,40 @@ import DeckScreen, { DeckDisplay } from '../../app/(app)/deck/index';
 
 // Mock AsyncStorage
 jest.mock('@react-native-async-storage/async-storage', () => ({
-    setItem: jest.fn(),
-    getItem: jest.fn(),
-    removeItem: jest.fn(),
+	setItem: jest.fn(),
+	getItem: jest.fn(),
+	removeItem: jest.fn(),
+	getAllKeys: jest.fn(() => Promise.resolve([])),
+	multiGet: jest.fn((keys) => Promise.resolve(keys.map((key: string) => [key, 'value']))),
+	multiSet: jest.fn(() => Promise.resolve()),
+	multiRemove: jest.fn(() => Promise.resolve()),
 }));
+// CommonMock.mockAsyncStorage();
+
+RepositoryMock.mockRepository<Memento.Deck>([{
+	name: 'Deck 1', cards: []
+}]);
 
 // Mock Firebase functions and firestore
 jest.mock('@/config/firebase', () => ({
-    callFunction: jest.fn(),
-    Collections: { deck: 'decks' }
+	callFunction: jest.fn(),
+	Collections: { deck: 'decks' }
 }));
 
 jest.mock('@/hooks/firebase/firestore', () => ({
-    useDynamicDocs: jest.fn(() => [
-        { id: '1', data: { name: 'Deck 1', cards: [] } }
-    ])
+	useDynamicDocs: jest.fn(() => [
+		{ id: '1', data: { name: 'Deck 1', cards: [] } }
+	])
 }));
 
 // Mock expo-router Stack and Screen
 jest.mock('expo-router', () => ({
-    router: { push: jest.fn() },
-    Stack: {
-        Screen: jest.fn(({ options }) => (
-            <>{options.title}</> // Simulate rendering the title for the test
-        )),
-    },
+	router: { push: jest.fn() },
+	Stack: {
+		Screen: jest.fn(({ options }) => (
+			<>{options.title}</> // Simulate rendering the title for the test
+		)),
+	},
 }));
 
 // ------------------------------------------------------------
@@ -55,197 +65,197 @@ jest.mock('expo-router', () => ({
 
 // Test cases for the DeckScreen component
 describe('DeckScreen', () => {
-    beforeEach(() => {
-        jest.clearAllMocks(); // Clear previous mocks before each test
-    });
+	beforeEach(() => {
+		jest.clearAllMocks(); // Clear previous mocks before each test
+	});
 
-    it('renders without crashing', () => {
-        const { getByText } = render(<DeckScreen />);
-        expect(getByText('Deck 1')).toBeTruthy();
-    });
+	it('renders without crashing', () => {
+		const { getByText } = render(<DeckScreen />);
+		expect(getByText('Deck 1')).toBeTruthy();
+	});
 
-    it('allows the user to input a deck name', () => {
-        const { getByPlaceholderText } = render(<DeckScreen />);
-        const input = getByPlaceholderText('My amazing deck');
-        fireEvent.changeText(input, 'New Deck');
-        expect(input.props.value).toBe('New Deck');
-    });
+	it('allows the user to input a deck name', () => {
+		const { getByPlaceholderText } = render(<DeckScreen />);
+		const input = getByPlaceholderText('My amazing deck');
+		fireEvent.changeText(input, 'New Deck');
+		expect(input.props.value).toBe('New Deck');
+	});
 
-    it('displays an error message when trying to create a deck with an existing name', async () => {
-        const { getByPlaceholderText, getByText } = render(<DeckScreen />);
-        const input = getByPlaceholderText('My amazing deck');
-        fireEvent.changeText(input, 'Deck 1'); // Use existing deck name
-        fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
-        expect(getByText('This name has already been used')).toBeTruthy();
-    });
+	it('displays an error message when trying to create a deck with an existing name', async () => {
+		const { getByPlaceholderText, getByText } = render(<DeckScreen />);
+		const input = getByPlaceholderText('My amazing deck');
+		fireEvent.changeText(input, 'Deck 1'); // Use existing deck name
+		fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
+		expect(getByText('This name has already been used')).toBeTruthy();
+	});
 
-    it('navigates to the deck details when a deck is pressed', () => {
-        const { getByText } = render(<DeckScreen />);
-        fireEvent.press(getByText('Deck 1'));
-        expect(router.push).toHaveBeenCalledWith('/deck/1');
-    });
+	it('navigates to the deck details when a deck is pressed', () => {
+		const { getByText } = render(<DeckScreen />);
+		fireEvent.press(getByText('Deck 1'));
+		expect(router.push).toHaveBeenCalledWith('/deck/1');
+	});
 
-    it('allows selecting and deleting decks', async () => {
-        const { getByText } = render(<DeckScreen />);
+	it('allows selecting and deleting decks', async () => {
+		const { getByText } = render(<DeckScreen />);
 
-        // Long press to select Deck 1
-        fireEvent(getByText('Deck 1'), 'longPress');
+		// Long press to select Deck 1
+		fireEvent(getByText('Deck 1'), 'longPress');
 
-        // Click delete button
-        fireEvent.press(getByText('Delete Selected Deck'));
-        expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteDecks, { deckIds: ['1'] });
-    });
+		// Click delete button
+		fireEvent.press(getByText('Delete Selected Deck'));
+		expect(callFunction).toHaveBeenCalledWith(Memento.Functions.deleteDecks, { deckIds: ['1'] });
+	});
 
-    it('allows cancelling selection mode', () => {
-        const { getByText } = render(<DeckScreen />);
+	it('allows cancelling selection mode', () => {
+		const { getByText } = render(<DeckScreen />);
 
-        // Long press to select Deck 1
-        fireEvent(getByText('Deck 1'), 'longPress');
+		// Long press to select Deck 1
+		fireEvent(getByText('Deck 1'), 'longPress');
 
-        // Click cancel button
-        fireEvent.press(getByText('Cancel'));
-        expect(callFunction).not.toHaveBeenCalled(); // Ensure delete function was not called
-    });
+		// Click cancel button
+		fireEvent.press(getByText('Cancel'));
+		expect(callFunction).not.toHaveBeenCalled(); // Ensure delete function was not called
+	});
 
-    it('allows cancelling selection mode when no decks are selected', () => {
-        const { getByText } = render(<DeckScreen />);
+	it('allows cancelling selection mode when no decks are selected', () => {
+		const { getByText } = render(<DeckScreen />);
 
-        // Long press to select Deck 1
-        fireEvent(getByText('Deck 1'), 'longPress');
-        fireEvent.press(getByText('Deck 1')); // Deselect Deck 1
+		// Long press to select Deck 1
+		fireEvent(getByText('Deck 1'), 'longPress');
+		fireEvent.press(getByText('Deck 1')); // Deselect Deck 1
 
-        expect(callFunction).not.toHaveBeenCalled(); // Ensure delete function was not called
-    });
+		expect(callFunction).not.toHaveBeenCalled(); // Ensure delete function was not called
+	});
 
-    it('does not create a deck if the name is empty', async () => {
-        const { getByPlaceholderText, getByText } = render(<DeckScreen />);
+	it('does not create a deck if the name is empty', async () => {
+		const { getByPlaceholderText, getByText } = render(<DeckScreen />);
 
-        const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
-        fireEvent.changeText(input, ''); // Set empty deck name
-        fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
+		const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
+		fireEvent.changeText(input, ''); // Set empty deck name
+		fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
 
-        expect(callFunction).not.toHaveBeenCalled(); // Ensure callFunction was not called
-    });
+		expect(callFunction).not.toHaveBeenCalled(); // Ensure callFunction was not called
+	});
 
-    it('does not create a deck if the name is a duplicate', async () => {
-        // Set up the mock data for existing decks
-        const existingDecks = [{ id: '1', data: { name: 'Deck 1' } }];
-        jest.mock('@/hooks/firebase/firestore', () => ({
-            useDynamicDocs: jest.fn(() => existingDecks), // Return existing decks
-        }));
+	it('does not create a deck if the name is a duplicate', async () => {
+		// Set up the mock data for existing decks
+		const existingDecks = [{ id: '1', data: { name: 'Deck 1' } }];
+		jest.mock('@/hooks/firebase/firestore', () => ({
+			useDynamicDocs: jest.fn(() => existingDecks), // Return existing decks
+		}));
 
-        const { getByPlaceholderText, getByText } = render(<DeckScreen />);
+		const { getByPlaceholderText, getByText } = render(<DeckScreen />);
 
-        const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
-        fireEvent.changeText(input, 'Deck 1'); // Use an existing deck name
-        fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
+		const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
+		fireEvent.changeText(input, 'Deck 1'); // Use an existing deck name
+		fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
 
-        expect(callFunction).not.toHaveBeenCalled(); // Ensure callFunction was not called
-    });
+		expect(callFunction).not.toHaveBeenCalled(); // Ensure callFunction was not called
+	});
 
-    it('creates a deck successfully when the name is unique', async () => {
-        const { getByPlaceholderText, getByText } = render(<DeckScreen />);
+	it('creates a deck successfully when the name is unique', async () => {
+		const { getByPlaceholderText, getByText } = render(<DeckScreen />);
 
-        // Mock successful response for creating a deck
-        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: 'newDeckId' } });
+		// Mock successful response for creating a deck
+		(callFunction as jest.Mock).mockResolvedValueOnce({ status: 1, data: { id: 'newDeckId' } });
 
-        const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
-        fireEvent.changeText(input, 'New Unique Deck'); // Set a unique deck name
-        fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
+		const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
+		fireEvent.changeText(input, 'New Unique Deck'); // Set a unique deck name
+		fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.createDeck, {
-                deck: {
-                    name: 'New Unique Deck',
-                    cards: []
-                },
-            }); // Ensure callFunction was called with correct arguments
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.createDeck, {
+				deck: {
+					name: 'New Unique Deck',
+					cards: []
+				},
+			}); // Ensure callFunction was called with correct arguments
+		});
+	});
 
-    it('handles errors when creating a deck', async () => {
-        const { getByPlaceholderText, getByText } = render(<DeckScreen />);
+	it('handles errors when creating a deck', async () => {
+		const { getByPlaceholderText, getByText } = render(<DeckScreen />);
 
-        // Mock an error response for creating a deck
-        (callFunction as jest.Mock).mockRejectedValueOnce(new Error('Network Error'));
+		// Mock an error response for creating a deck
+		(callFunction as jest.Mock).mockRejectedValueOnce(new Error('Network Error'));
 
-        const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
-        fireEvent.changeText(input, 'Unique Deck'); // Set a unique deck name
-        fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
+		const input = getByPlaceholderText('My amazing deck'); // Change this based on your placeholder
+		fireEvent.changeText(input, 'Unique Deck'); // Set a unique deck name
+		fireEvent.press(getByText('Create Deck')); // Press the button to create the deck
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalled(); // Ensure callFunction was called
-            // Optionally, you can check for an error message in your UI
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalled(); // Ensure callFunction was called
+			// Optionally, you can check for an error message in your UI
+		});
+	});
 });
 
 // Test cases for the DeckDisplay component
 describe('DeckDisplay', () => {
-    const mockDeck: Memento.Deck = {
-        name: 'Test Deck',
-        cards: [{ question: 'What is 2 + 2?', answer: '4', learning_status: 'Got it' }],
-    };
+	const mockDeck: Memento.Deck = {
+		name: 'Test Deck',
+		cards: [{ question: 'What is 2 + 2?', answer: '4', learning_status: 'Got it' }],
+	};
 
-    const mockToggleSelection = jest.fn();
-    const mockOnLongPress = jest.fn();
+	const mockToggleSelection = jest.fn();
+	const mockOnLongPress = jest.fn();
 
-    it('navigates to the deck details when not in selection mode', () => {
-        const { getByText } = render(
-            <DeckDisplay
-                deck={mockDeck}
-                id="1"
-                isSelected={false}
-                toggleSelection={mockToggleSelection}
-                onLongPress={mockOnLongPress}
-                selectionMode={false}
-            />
-        );
+	it('navigates to the deck details when not in selection mode', () => {
+		const { getByText } = render(
+			<DeckDisplay
+				deck={mockDeck}
+				id="1"
+				isSelected={false}
+				toggleSelection={mockToggleSelection}
+				onLongPress={mockOnLongPress}
+				selectionMode={false}
+			/>
+		);
 
-        // Simulate press on the DeckDisplay
-        fireEvent.press(getByText('Test Deck'));
+		// Simulate press on the DeckDisplay
+		fireEvent.press(getByText('Test Deck'));
 
-        // Check that the router pushed to the correct path
-        expect(router.push).toHaveBeenCalledWith('/deck/1');
-        expect(mockToggleSelection).not.toHaveBeenCalled(); // Should not be called since selectionMode is false
-    });
+		// Check that the router pushed to the correct path
+		expect(router.push).toHaveBeenCalledWith('/deck/1');
+		expect(mockToggleSelection).not.toHaveBeenCalled(); // Should not be called since selectionMode is false
+	});
 
-    it('toggles selection when in selection mode', () => {
-        const { getByText } = render(
-            <DeckDisplay
-                deck={mockDeck}
-                id="1"
-                isSelected={false}
-                toggleSelection={mockToggleSelection}
-                onLongPress={mockOnLongPress}
-                selectionMode={true}
-            />
-        );
+	it('toggles selection when in selection mode', () => {
+		const { getByText } = render(
+			<DeckDisplay
+				deck={mockDeck}
+				id="1"
+				isSelected={false}
+				toggleSelection={mockToggleSelection}
+				onLongPress={mockOnLongPress}
+				selectionMode={true}
+			/>
+		);
 
-        // Simulate press on the DeckDisplay
-        fireEvent.press(getByText('Test Deck'));
+		// Simulate press on the DeckDisplay
+		fireEvent.press(getByText('Test Deck'));
 
-        // Check that toggleSelection is called
-        expect(mockToggleSelection).toHaveBeenCalledWith(mockDeck);
-    });
+		// Check that toggleSelection is called
+		expect(mockToggleSelection).toHaveBeenCalledWith(mockDeck);
+	});
 
-    it('calls toggleSelection and onLongPress when long pressed', () => {
-        const { getByText } = render(
-            <DeckDisplay
-                deck={mockDeck}
-                id="1"
-                isSelected={false}
-                toggleSelection={mockToggleSelection}
-                onLongPress={mockOnLongPress}
-                selectionMode={true}
-            />
-        );
+	it('calls toggleSelection and onLongPress when long pressed', () => {
+		const { getByText } = render(
+			<DeckDisplay
+				deck={mockDeck}
+				id="1"
+				isSelected={false}
+				toggleSelection={mockToggleSelection}
+				onLongPress={mockOnLongPress}
+				selectionMode={true}
+			/>
+		);
 
-        // Simulate long press on the DeckDisplay
-        fireEvent(getByText('Test Deck'), 'longPress');
+		// Simulate long press on the DeckDisplay
+		fireEvent(getByText('Test Deck'), 'longPress');
 
-        // Check that toggleSelection and onLongPress are called
-        expect(mockToggleSelection).toHaveBeenCalledWith(mockDeck);
-        expect(mockOnLongPress).toHaveBeenCalled();
-    });
+		// Check that toggleSelection and onLongPress are called
+		expect(mockToggleSelection).toHaveBeenCalledWith(mockDeck);
+		expect(mockOnLongPress).toHaveBeenCalled();
+	});
 });

--- a/edweiss-app/__test__/memento/editCard.test.tsx
+++ b/edweiss-app/__test__/memento/editCard.test.tsx
@@ -12,6 +12,7 @@ import EditCardScreen from '@/app/(app)/deck/[id]/card/edition';
 import { callFunction } from '@/config/firebase';
 import Memento from '@/model/memento';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { RepositoryMock } from '../__mocks__/repository';
 
 // ------------------------------------------------------------
 // ---------------------  Mock Data & Setup  ------------------
@@ -19,32 +20,63 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native';
 
 // Mock card data
 const card1: Memento.Card = {
-    question: 'Question 0',
-    answer: 'Answer 0',
-    learning_status: 'Got it',
+	question: 'Question 0',
+	answer: 'Answer 0',
+	learning_status: 'Got it',
 };
+
+// jest.mock('@react-native-async-storage/async-storage', () => ({
+// 	setItem: jest.fn(),
+// 	getItem: jest.fn(),
+// 	removeItem: jest.fn(),
+// 	getAllKeys: jest.fn()
+// }));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+	setItem: jest.fn(),
+	getItem: jest.fn(),
+	removeItem: jest.fn(),
+	getAllKeys: jest.fn(() => Promise.resolve([])),
+	multiGet: jest.fn((keys) => Promise.resolve(keys.map((key: string) => [key, 'value']))),
+	multiSet: jest.fn(() => Promise.resolve()),
+	multiRemove: jest.fn(() => Promise.resolve()),
+}));
+
+RepositoryMock.mockRepository<Memento.Deck>([{
+	name: 'Deck 1', cards: [{
+		answer: "Answer",
+		question: "Question",
+		learning_status: "Got it",
+	}]
+}]);
+
+RepositoryMock.mockRepository<Memento.Deck>([{
+	name: 'Deck 0', cards: [card1]
+}]);
+
+// CommonMock.mockAsyncStorage();
 
 // Mock Firebase functions and firestore
 jest.mock('@/config/firebase', () => ({
-    callFunction: jest.fn(),
-    Collections: { deck: 'decks' }
+	callFunction: jest.fn(),
+	Collections: { deck: 'decks' }
 }));
 
 jest.mock('@/hooks/firebase/firestore', () => ({
-    useDynamicDocs: jest.fn(() => [
-        { id: '0', data: { name: 'Deck 0', cards: [card1] } }
-    ]),
+	useDynamicDocs: jest.fn(() => [
+		{ id: '1', data: { name: 'Deck 0', cards: [card1] } }
+	]),
 }));
 
 // Mock expo-router Stack and Screen
 jest.mock('expo-router', () => ({
-    router: { push: jest.fn(), back: jest.fn() },
-    Stack: {
-        Screen: jest.fn(({ options }) => (
-            <>{options.headerRight()}, {options.headerLeft()}</>
-        )),
-    },
-    useLocalSearchParams: jest.fn(() => ({ deckId: '0', prev_question: 'Question 0', prev_answer: 'Answer 0', cardIndex: '0' })),
+	router: { push: jest.fn(), back: jest.fn() },
+	Stack: {
+		Screen: jest.fn(({ options }) => (
+			<>{options.headerRight()}, {options.headerLeft()}</>
+		)),
+	},
+	useLocalSearchParams: jest.fn(() => ({ deckId: '1', prev_question: 'Question 0', prev_answer: 'Answer 0', cardIndex: '0' })),
 }));
 
 // ------------------------------------------------------------
@@ -54,47 +86,47 @@ jest.mock('expo-router', () => ({
 // Test suite for the EditCardScreen component
 describe('EditCardScreen', () => {
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should render correctly', () => {
-        const { getByText, getByTestId } = render(<EditCardScreen />);
-        expect(getByText('Question')).toBeTruthy();
-        expect(getByText('Answer')).toBeTruthy();
-        expect(getByTestId('updateCardButton')).toBeTruthy();
-    });
+	it('should render correctly', () => {
+		const { getByText, getByTestId } = render(<EditCardScreen />);
+		expect(getByText('Question')).toBeTruthy();
+		expect(getByText('Answer')).toBeTruthy();
+		expect(getByTestId('updateCardButton')).toBeTruthy();
+	});
 
-    it('should display the correct previous question and answer', () => {
-        const { getByDisplayValue } = render(<EditCardScreen />);
-        expect(getByDisplayValue('Question 0')).toBeTruthy();
-        expect(getByDisplayValue('Answer 0')).toBeTruthy();
-    });
+	it('should display the correct previous question and answer', () => {
+		const { getByDisplayValue } = render(<EditCardScreen />);
+		expect(getByDisplayValue('Question 0')).toBeTruthy();
+		expect(getByDisplayValue('Answer 0')).toBeTruthy();
+	});
 
-    it('should update a card when the fields are filled', async () => {
-        const { getByTestId, getByDisplayValue } = render(<EditCardScreen />);
-        const updateButton = getByTestId('updateCardButton');
+	it('should update a card when the fields are filled', async () => {
+		const { getByTestId, getByDisplayValue } = render(<EditCardScreen />);
+		const updateButton = getByTestId('updateCardButton');
 
-        fireEvent.changeText(getByDisplayValue('Question 0'), 'Test Question');
-        fireEvent.changeText(getByDisplayValue('Answer 0'), 'Test Answer');
+		fireEvent.changeText(getByDisplayValue('Question 0'), 'Test Question');
+		fireEvent.changeText(getByDisplayValue('Answer 0'), 'Test Answer');
 
-        expect(getByDisplayValue('Test Question')).toBeTruthy();
+		expect(getByDisplayValue('Test Question')).toBeTruthy();
 
-        // Mock successful response for creating a card
-        (callFunction as jest.Mock).mockResolvedValueOnce({ status: 1 });
+		// Mock successful response for creating a card
+		(callFunction as jest.Mock).mockResolvedValueOnce({ status: 1 });
 
-        fireEvent.press(updateButton);
+		fireEvent.press(updateButton);
 
-        await waitFor(() => {
-            expect(callFunction).toHaveBeenCalledWith(Memento.Functions.updateCard, {
-                deckId: '0',
-                newCard: {
-                    question: 'Test Question',
-                    answer: 'Test Answer',
-                    learning_status: 'Got it',
-                },
-                cardIndex: 0
-            });
-        });
-    });
+		await waitFor(() => {
+			expect(callFunction).toHaveBeenCalledWith(Memento.Functions.updateCard, {
+				deckId: '0',
+				newCard: {
+					question: 'Test Question',
+					answer: 'Test Answer',
+					learning_status: 'Got it',
+				},
+				cardIndex: 0
+			});
+		});
+	});
 });

--- a/edweiss-app/app/(app)/(tabs)/community.tsx
+++ b/edweiss-app/app/(app)/(tabs)/community.tsx
@@ -2,12 +2,8 @@ import TText from '@/components/core/TText';
 import TView from '@/components/core/containers/TView';
 import RouteHeader from '@/components/core/header/RouteHeader';
 import FancyButton from '@/components/input/FancyButton';
-import { callFunction } from '@/config/firebase';
 import { ApplicationRoute } from '@/constants/Component';
-import Experiments from '@/model/experiments';
 import { router } from 'expo-router';
-import { useState } from 'react';
-
 
 const CommunityTab: ApplicationRoute = () => {
 	return (
@@ -20,11 +16,11 @@ const CommunityTab: ApplicationRoute = () => {
 				</TText>
 			</TView>
 
-			<FancyButton mt={10} mb={10} onPress={() => router.push("deck" as any)} backgroundColor='pink'>
+			<FancyButton mt={10} mb={10} onPress={() => router.push("/deck")} backgroundColor='pink'>
 				Memento App
-			</FancyButton >
+			</FancyButton>
 
-			<FancyButton mt={'md'} mb={'md'} onPress={() => router.push(`/(app)/todo` as any)}>
+			<FancyButton mt={'md'} mb={'md'} onPress={() => router.push(`/(app)/todo`)}>
 				My Todos
 			</FancyButton>
 		</>

--- a/edweiss-app/app/(app)/(tabs)/index.tsx
+++ b/edweiss-app/app/(app)/(tabs)/index.tsx
@@ -139,8 +139,8 @@ const CourseDisplay: ReactComponent<{ course: Document<Course> }> = ({ course })
 
 const AssignmentDisplay: ReactComponent<{ assignment: Document<Assignment> }> = ({ assignment }) => {
 	return (
-		<TView flexDirection='row' justifyContent='space-between'>
-			<TText>
+		<TView flexColumnGap={'md'} flexDirection='row' justifyContent='space-between'>
+			<TText numberOfLines={1} style={{ flex: 1 }}>
 				{assignment.data.name}
 			</TText>
 			<TText color='subtext0'>

--- a/edweiss-app/app/(app)/_layout.tsx
+++ b/edweiss-app/app/(app)/_layout.tsx
@@ -25,7 +25,7 @@ const AppLayout: ApplicationLayout = () => {
 
 	return (
 		<CoursesProvider>
-			<Stack>
+			<Stack screenOptions={{ headerShown: false }}>
 				<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
 			</Stack>
 		</CoursesProvider>

--- a/edweiss-app/app/(app)/deck/[id]/card/edition/index.tsx
+++ b/edweiss-app/app/(app)/deck/[id]/card/edition/index.tsx
@@ -18,11 +18,13 @@ import TScrollView from '@/components/core/containers/TScrollView';
 import TView from '@/components/core/containers/TView';
 import FancyButton from '@/components/input/FancyButton';
 import FancyTextInput from '@/components/input/FancyTextInput';
-import { callFunction, Collections } from '@/config/firebase';
-import { useDynamicDocs } from '@/hooks/firebase/firestore';
+import { callFunction } from '@/config/firebase';
+import { useRepositoryDocument } from '@/hooks/repository';
+import { useStringParameters } from '@/hooks/routeParameters';
 import Memento from '@/model/memento';
-import { router, useLocalSearchParams } from 'expo-router';
+import { Redirect, router } from 'expo-router';
 import React, { useState } from 'react';
+import { DecksRepository } from '../../../_layout';
 
 // ------------------------------------------------------------
 // ----------------- EditCardScreen Component -----------------
@@ -35,77 +37,92 @@ import React, { useState } from 'react';
  * @returns {ApplicationRoute} Screen to edit a card
  */
 const EditCardScreen: ApplicationRoute = () => {
-    const { deckId, prev_question, prev_answer, cardIndex } = useLocalSearchParams();
-    const [question, setQuestion] = useState(prev_question as string);
-    const [answer, setAnswer] = useState(prev_answer as string);
+	const { deckId, prev_question, prev_answer, cardIndex } = useStringParameters();
+	const [question, setQuestion] = useState(prev_question as string);
+	const [answer, setAnswer] = useState(prev_answer as string);
 
-    const decks = useDynamicDocs(Collections.deck);
-    const deck = decks?.find(d => d.id == deckId);
-    const cardIndexInt = cardIndex ? parseInt(cardIndex.toString()) : 0;
+	// const decks = useDynamicDocs(Collections.deck);
+	// const deck = decks?.find(d => d.id == deckId);
+	const [deck, handler] = useRepositoryDocument(deckId, DecksRepository);
+	if (deck == undefined)
+		return <Redirect href={'/'} />;
 
-    const card = deck?.data.cards[cardIndexInt];
+	const cardIndexInt = cardIndex ? parseInt(cardIndex.toString()) : 0;
 
-    // Update a card with a new question and answer
-    async function updateCard() {
+	const card = deck.data.cards[cardIndexInt];
 
-        const res = await callFunction(Memento.Functions.updateCard, { deckId: deckId as any, newCard: card, cardIndex: cardIndexInt });
+	// Update a card with a new question and answer
+	async function updateCard() {
+		if (deck == undefined)
+			return;
 
-        if (res.status == 1) {
-            console.log(`OKAY, card updated with index ${cardIndexInt}`);
-            router.back();
-        }
+		const newCards = deck.data.cards;
+		newCards[cardIndexInt] = card;
 
-    }
+		handler.modifyDocument(deckId, {
+			cards: newCards
+		}, (deckId) => {
+			callFunction(Memento.Functions.updateCard, { deckId, newCard: card, cardIndex: cardIndexInt });
+		});
 
-    return (
-        <>
-            <RouteHeader title='Edit card' />
 
-            <TScrollView>
-                {/* <TextInput value={deckName} onChangeText={n => setDeckName(n)} placeholder='Deck name' placeholderTextColor={'#555'} style={{ backgroundColor: Colors.dark.crust, borderColor: Colors.dark.blue, borderWidth: 1, padding: 8, paddingHorizontal: 16, margin: 16, marginBottom: 0, color: 'white', borderRadius: 14, fontFamily: "Inter" }}>
+		// console.log(`OKAY, card updated with index ${cardIndexInt}`);
+		// if (res.status == 1) {
+		// }
+
+		router.back();
+
+	}
+
+	return (
+		<>
+			<RouteHeader title='Edit card' />
+
+			<TScrollView>
+				{/* <TextInput value={deckName} onChangeText={n => setDeckName(n)} placeholder='Deck name' placeholderTextColor={'#555'} style={{ backgroundColor: Colors.dark.crust, borderColor: Colors.dark.blue, borderWidth: 1, padding: 8, paddingHorizontal: 16, margin: 16, marginBottom: 0, color: 'white', borderRadius: 14, fontFamily: "Inter" }}>
 
 				</TextInput> */}
-                <TView testID='questionInput' m='md' borderColor='crust' radius='lg'>
-                    <FancyTextInput
-                        value={question}
-                        onChangeText={n => setQuestion(n)}
-                        placeholder='My amazing question'
-                        icon='help-sharp'
-                        label='Question'
-                        //error='Invalid deck name'
-                        multiline
-                        numberOfLines={3}
-                    />
-                </TView>
+				<TView testID='questionInput' m='md' borderColor='crust' radius='lg'>
+					<FancyTextInput
+						value={question}
+						onChangeText={n => setQuestion(n)}
+						placeholder='My amazing question'
+						icon='help-sharp'
+						label='Question'
+						//error='Invalid deck name'
+						multiline
+						numberOfLines={3}
+					/>
+				</TView>
 
-                <TView m='md' mt={2} borderColor='crust' radius='lg'>
-                    <FancyTextInput
-                        value={answer}
-                        onChangeText={n => setAnswer(n)}
-                        placeholder='My amazing answer'
-                        icon='bulb-outline'
-                        label='Answer'
-                        //error='Invalid deck name'
-                        multiline
-                        numberOfLines={3}
-                    />
-                </TView>
+				<TView m='md' mt={2} borderColor='crust' radius='lg'>
+					<FancyTextInput
+						value={answer}
+						onChangeText={n => setAnswer(n)}
+						placeholder='My amazing answer'
+						icon='bulb-outline'
+						label='Answer'
+						//error='Invalid deck name'
+						multiline
+						numberOfLines={3}
+					/>
+				</TView>
 
-                <FancyButton testID='updateCardButton' onPress={() => updateQuestionAnswerCard(deckId as any, cardIndexInt, updateCard, question, answer, card)} backgroundColor='blue' mt={'md'} mb={'sm'} icon='logo-firebase' mx={300} >
-                    Done!
-                </FancyButton>
+				<FancyButton testID='updateCardButton' onPress={() => updateQuestionAnswerCard(deckId as any, cardIndexInt, updateCard, question, answer, card)} backgroundColor='blue' mt={'md'} mb={'sm'} icon='logo-firebase' mx={300} >
+					Done!
+				</FancyButton>
 
-            </TScrollView >
-        </>
-    );
+			</TScrollView >
+		</>
+	);
 };
 
 export default EditCardScreen;
 
 function updateQuestionAnswerCard(deckId: string, cardIndex: number, onPress: (deckId: any, newCard: Memento.Card, cardIndex: number) => void, newQuestion: string, newAnswer: string, card?: Memento.Card) {
-    if (card) {
-        card.answer = newAnswer;
-        card.question = newQuestion;
-        onPress(deckId, card, cardIndex);
-    }
+	if (card) {
+		card.answer = newAnswer;
+		card.question = newQuestion;
+		onPress(deckId, card, cardIndex);
+	}
 }

--- a/edweiss-app/app/(app)/deck/[id]/index.tsx
+++ b/edweiss-app/app/(app)/deck/[id]/index.tsx
@@ -63,8 +63,6 @@ const CardListScreen: ApplicationRoute = () => {
 
 	const sortedCards = sortingCards(cards);
 
-	console.log(deck.data);
-
 	// Toggle card selection
 	const toggleCardSelection = (card: Memento.Card) => {
 		const index = selectedCards.findIndex(selected => selected.question === card.question);

--- a/edweiss-app/app/(app)/deck/[id]/playingCards.tsx
+++ b/edweiss-app/app/(app)/deck/[id]/playingCards.tsx
@@ -13,21 +13,22 @@
 // --------------- Import Modules & Components ----------------
 // ------------------------------------------------------------
 
-import TView from '@/components/core/containers/TView';
 import TText from '@/components/core/TText';
+import TView from '@/components/core/containers/TView';
 import CardScreenComponent from '@/components/memento/CardScreenComponent';
-import { Collections } from '@/config/firebase';
 import { ApplicationRoute } from '@/constants/Component';
-import { useDoc } from '@/hooks/firebase/firestore';
+import { useRepositoryDocument } from '@/hooks/repository';
+import { useStringParameters } from '@/hooks/routeParameters';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import { useLocalSearchParams } from 'expo-router';
+import { Redirect } from 'expo-router';
 import React, { forwardRef, useRef, useState } from 'react';
 import { View, ViewProps } from 'react-native';
 import { PanGestureHandler, PanGestureHandlerStateChangeEvent, State } from 'react-native-gesture-handler';
+import { DecksRepository } from '../_layout';
 
 // Forward ref to TView component and type the ref as a View
 const TViewWithRef = forwardRef<View, ViewProps>((props, ref) => (
-    <View ref={ref} {...props} />
+	<View ref={ref} {...props} />
 ));
 
 /**
@@ -39,67 +40,71 @@ const TViewWithRef = forwardRef<View, ViewProps>((props, ref) => (
  * @returns {ApplicationRoute} Screen to test the user's knowledge of the deck
  */
 const TestYourMightScreen: ApplicationRoute = () => {
-    const { id } = useLocalSearchParams(); // Get deckId from params
-    const [currentCardIndex, setCurrentCardIndex] = useState(0);
-    const modalRef = useRef<BottomSheetModal>(null); // Reference for the modal
+	const { id } = useStringParameters(); // Get deckId from params
+	const [currentCardIndex, setCurrentCardIndex] = useState(0);
+	const modalRef = useRef<BottomSheetModal>(null); // Reference for the modal
 
-    const deck = useDoc(Collections.deck, id as string);
-    const cards = deck?.data.cards;
+	// const deck = useDoc(Collections.deck, id as string);
+	const [deck] = useRepositoryDocument(id, DecksRepository);
+	if (deck == undefined)
+		return <Redirect href={'/'} />;
 
-    // Handle next card
-    const handleNext = () => {
-        if (cards && currentCardIndex < cards.length - 1) {
-            setCurrentCardIndex((prevIndex) => prevIndex + 1);
-        }
-    };
+	const cards = deck?.data.cards;
 
-    // Handle previous card
-    const handlePrevious = () => {
-        if (cards && currentCardIndex > 0) {
-            setCurrentCardIndex((prevIndex) => prevIndex - 1);
-        }
-    };
+	// Handle next card
+	const handleNext = () => {
+		if (cards && currentCardIndex < cards.length - 1) {
+			setCurrentCardIndex((prevIndex) => prevIndex + 1);
+		}
+	};
 
-    // Handle swipe gestures
-    const handleGesture = ({ nativeEvent }: PanGestureHandlerStateChangeEvent) => {
-        if (nativeEvent.state === State.END) {
-            const { translationX } = nativeEvent;
+	// Handle previous card
+	const handlePrevious = () => {
+		if (cards && currentCardIndex > 0) {
+			setCurrentCardIndex((prevIndex) => prevIndex - 1);
+		}
+	};
 
-            // Detect swipe left
-            if (translationX < -50) {
-                handleNext();
-            }
+	// Handle swipe gestures
+	const handleGesture = ({ nativeEvent }: PanGestureHandlerStateChangeEvent) => {
+		if (nativeEvent.state === State.END) {
+			const { translationX } = nativeEvent;
 
-            // Detect swipe right
-            if (translationX > 50) {
-                handlePrevious();
-            }
-        }
-    };
+			// Detect swipe left
+			if (translationX < -50) {
+				handleNext();
+			}
 
-    return (
-        <>
-            {cards && cards.length > 0 && (
-                <>
-                    <TView style={{ position: 'absolute', top: '5%', left: '50%' }}>
-                        <TText color='blue' size={20}>
-                            {currentCardIndex + 1}/{cards.length}
-                        </TText>
-                    </TView>
-                    <PanGestureHandler onHandlerStateChange={handleGesture} testID='pan-gesture'>
-                        <TViewWithRef style={{ flex: 1 }}>
-                            <CardScreenComponent
-                                deckId={id as string}
-                                cardIndex={currentCardIndex}
-                                modalRef={modalRef}
-                            />
-                        </TViewWithRef>
-                    </PanGestureHandler>
+			// Detect swipe right
+			if (translationX > 50) {
+				handlePrevious();
+			}
+		}
+	};
 
-                </>
-            )}
-        </>
-    );
+	return (
+		<>
+			{cards && cards.length > 0 && (
+				<>
+					<TView style={{ position: 'absolute', top: '5%', left: '50%' }}>
+						<TText color='blue' size={20}>
+							{currentCardIndex + 1}/{cards.length}
+						</TText>
+					</TView>
+					<PanGestureHandler onHandlerStateChange={handleGesture} testID='pan-gesture'>
+						<TViewWithRef style={{ flex: 1 }}>
+							<CardScreenComponent
+								deckId={id as string}
+								cardIndex={currentCardIndex}
+								modalRef={modalRef}
+							/>
+						</TViewWithRef>
+					</PanGestureHandler>
+
+				</>
+			)}
+		</>
+	);
 };
 
 export default TestYourMightScreen;

--- a/edweiss-app/app/(app)/deck/_layout.tsx
+++ b/edweiss-app/app/(app)/deck/_layout.tsx
@@ -1,4 +1,4 @@
-import { Collections } from '@/config/firebase';
+import { CollectionOf } from '@/config/firebase';
 import { ApplicationLayout } from '@/constants/Component';
 import { RepositoryLayout, createRepository } from '@/hooks/repository';
 import Memento from '@/model/memento';
@@ -6,7 +6,8 @@ import Memento from '@/model/memento';
 export const DecksRepository = createRepository<Memento.Deck>("my-decks");
 
 const MementoLayout: ApplicationLayout = () => {
-	return <RepositoryLayout signature={DecksRepository} collection={Collections.deck} />;
+	const collection = CollectionOf<Memento.Deck>("decks");
+	return <RepositoryLayout repository={DecksRepository} collection={collection} />;
 };
 
 export default MementoLayout;

--- a/edweiss-app/app/(app)/deck/_layout.tsx
+++ b/edweiss-app/app/(app)/deck/_layout.tsx
@@ -1,0 +1,12 @@
+import { Collections } from '@/config/firebase';
+import { ApplicationLayout } from '@/constants/Component';
+import { RepositoryLayout, createRepository } from '@/hooks/repository';
+import Memento from '@/model/memento';
+
+export const DecksRepository = createRepository<Memento.Deck>("my-decks");
+
+const MementoLayout: ApplicationLayout = () => {
+	return <RepositoryLayout signature={DecksRepository} collection={Collections.deck} />;
+};
+
+export default MementoLayout;

--- a/edweiss-app/app/(app)/deck/index.tsx
+++ b/edweiss-app/app/(app)/deck/index.tsx
@@ -18,13 +18,14 @@ import TView from '@/components/core/containers/TView';
 import RouteHeader from '@/components/core/header/RouteHeader';
 import FancyButton from '@/components/input/FancyButton';
 import FancyTextInput from '@/components/input/FancyTextInput';
-import { callFunction, Collections } from '@/config/firebase';
+import { callFunction } from '@/config/firebase';
 import t from '@/config/i18config';
 import ReactComponent, { ApplicationRoute } from '@/constants/Component';
-import { useDynamicDocs } from '@/hooks/firebase/firestore';
+import { useRepository } from '@/hooks/repository';
 import Memento from '@/model/memento';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
+import { DecksRepository } from './_layout';
 
 // ------------------------------------------------------------
 // ---------------------  DeckScreen Component -----------------
@@ -36,142 +37,153 @@ import React, { useState } from 'react';
  * @returns {ApplicationRoute} DeckScreen component
  */
 const DeckScreen: ApplicationRoute = () => {
-    const [deckName, setDeckName] = useState("");
-    const [existedDeckName, setExistedDeckName] = useState(false);
-    const [selectedDecks, setSelectedDecks] = useState<Memento.Deck[]>([]);
-    const [selectionMode, setSelectionMode] = useState(false); // Track selection mode
+	const [deckName, setDeckName] = useState("");
+	const [existedDeckName, setExistedDeckName] = useState(false);
+	const [selectedDecks, setSelectedDecks] = useState<Memento.Deck[]>([]);
+	const [selectionMode, setSelectionMode] = useState(false); // Track selection mode
 
-    const decks = useDynamicDocs(Collections.deck);
+	// const decks = useDynamicDocs(Collections.deck);
+	const [decks, handler] = useRepository(DecksRepository);
 
-    // Create a new deck
-    async function call() {
-        const trimmedDeckName = deckName.trim();
+	// Create a new deck
+	async function call() {
+		const trimmedDeckName = deckName.trim();
 
-        if (trimmedDeckName.length == 0 || existedDeckName)
-            return;
+		if (trimmedDeckName.length == 0 || existedDeckName)
+			return;
 
-        const isDuplicate = decks?.some(deck => deck.data.name === trimmedDeckName);
-        if (isDuplicate) {
-            setExistedDeckName(true);
-            return;  // Prevent creation if a duplicate is found
-        }
+		const isDuplicate = decks?.some(deck => deck.data.name === trimmedDeckName);
+		if (isDuplicate) {
+			setExistedDeckName(true);
+			return;  // Prevent creation if a duplicate is found
+		}
 
-        try {
-            const res = await callFunction(Memento.Functions.createDeck, {
-                deck: {
-                    name: deckName,
-                    cards: []
-                }
-            });
+		try {
+			const deck = {
+				name: deckName,
+				cards: []
+			}
+			handler.addDocument(deck, callFunction(Memento.Functions.createDeck, { deck }));
+			setDeckName(""); // Clear the input field after successful creation
 
-            if (res.status === 1) {
-                console.log(`OKAY, deck created with id ${res.data.id}`);
-                setDeckName(""); // Clear the input field after successful creation
-            }
-        } catch (error) {
-            console.error("Failed to create deck:", error);
-            // Optionally, set an error state to inform the user
-        }
-    }
+			// const res = await callFunction(Memento.Functions.createDeck, { deck });
 
-    // Toggle deck selection
-    const toggleDeckSelection = (deck: Memento.Deck) => {
-        const index = selectedDecks.findIndex(selected => selected.name === deck.name); // Find index of the selected deck
+			// if (res.status === 1) {
+			// 	console.log(`OKAY, deck created with id ${res.data.id}`);
+			// }
+		} catch (error) {
+			console.error("Failed to create deck:", error);
+			// Optionally, set an error state to inform the user
+		}
+	}
 
-        setSelectedDecks(prev =>
-            index >= 0
-                ? prev.filter(selected => selected.name !== deck.name) // Remove from selection
-                : [...prev, deck] // Add to selection
-        );
+	// Toggle deck selection
+	const toggleDeckSelection = (deck: Memento.Deck) => {
+		const index = selectedDecks.findIndex(selected => selected.name === deck.name); // Find index of the selected deck
 
-        // Exit selection mode immediately if all decks are deselected
-        if (index >= 0 && selectedDecks.length === 1) {
-            setSelectionMode(false);  // Exit selection mode when the last deck is deselected
-        }
-    };
+		setSelectedDecks(prev =>
+			index >= 0
+				? prev.filter(selected => selected.name !== deck.name) // Remove from selection
+				: [...prev, deck] // Add to selection
+		);
 
-    // Delete selected decks
-    const deleteSelectedDecks = async () => {
-        if (selectedDecks.length === 0) return;
+		// Exit selection mode immediately if all decks are deselected
+		if (index >= 0 && selectedDecks.length === 1) {
+			setSelectionMode(false);  // Exit selection mode when the last deck is deselected
+		}
+	};
 
-        const deckIds = selectedDecks.map(deck => decks?.filter(d => d.data.name === deck.name)[0].id);
+	// Delete selected decks
+	const deleteSelectedDecks = async () => {
+		if (selectedDecks.length === 0) return;
 
-        await callFunction(Memento.Functions.deleteDecks, {
-            deckIds: deckIds
-        });
-        setSelectedDecks([]); // Clear selection after deletion
-        setSelectionMode(false); // Exit selection mode
-    };
+		const deckIds = selectedDecks.map(deck => decks?.filter(d => d.data.name === deck.name)[0].id) as string[];
 
-    const cancelSelection = () => {
-        setSelectedDecks([]); // Clear selection
-        setSelectionMode(false); // Exit selection mode
-    };
+		if (deckIds == undefined)
+			return;
 
-    const enterSelectionMode = () => {
-        setSelectionMode(true); // Activate selection mode on long press
-    };
+		handler.deleteDocuments(deckIds, (ids) => {
+			callFunction(Memento.Functions.deleteDecks, {
+				deckIds: ids
+			});
+		});
 
-    return (
-        <>
-            <RouteHeader title={"Decks"} />
+		// await callFunction(Memento.Functions.deleteDecks, {
+		// 	deckIds: deckIds
+		// });
+		setSelectedDecks([]); // Clear selection after deletion
+		setSelectionMode(false); // Exit selection mode
+	};
 
-            <TScrollView>
+	const cancelSelection = () => {
+		setSelectedDecks([]); // Clear selection
+		setSelectionMode(false); // Exit selection mode
+	};
 
-                <FancyTextInput
-                    value={deckName}
-                    onChangeText={n => {
-                        setDeckName(n);
-                        setExistedDeckName(false);
-                    }}
-                    placeholder='My amazing deck'
-                    icon='dice'
-                    label='Deck name'
-                    error={existedDeckName ? 'This name has already been used' : undefined}
-                    multiline
-                    numberOfLines={3}
-                />
+	const enterSelectionMode = () => {
+		setSelectionMode(true); // Activate selection mode on long press
+	};
 
-                <FancyButton backgroundColor='blue' mt={'md'} mb={'sm'} onPress={call} icon='logo-firebase'>
-                    {t("memento:create-deck")}
-                </FancyButton>
+	return (
+		<>
+			<RouteHeader title={"Decks"} />
 
-                {selectedDecks.length > 0 && (
-                    <TView mt={'md'} style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                        <FancyButton
-                            backgroundColor='red'
-                            onPress={deleteSelectedDecks}
-                            mb={'sm'}
-                            style={{ flex: 1 }}
-                        >
-                            Delete Selected Deck
-                        </FancyButton>
+			<TScrollView>
 
-                        <FancyButton
-                            backgroundColor='blue'
-                            onPress={cancelSelection}
-                            style={{ flex: 1 }}
-                        >
-                            Cancel
-                        </FancyButton>
-                    </TView>
-                )}
+				<FancyTextInput
+					value={deckName}
+					onChangeText={n => {
+						setDeckName(n);
+						setExistedDeckName(false);
+					}}
+					placeholder='My amazing deck'
+					icon='dice'
+					label='Deck name'
+					error={existedDeckName ? 'This name has already been used' : undefined}
+					multiline
+					numberOfLines={3}
+				/>
 
-                <For each={decks}>
-                    {deck =>
-                        <DeckDisplay
-                            key={deck.id}
-                            deck={deck.data}
-                            id={deck.id}
-                            isSelected={selectedDecks.some(selected => selected.name === deck.data.name)}
-                            toggleSelection={toggleDeckSelection}
-                            onLongPress={enterSelectionMode}
-                            selectionMode={selectionMode}
-                        />}
-                </For>
-            </TScrollView>
-        </>
-    );
+				<FancyButton backgroundColor='blue' mt={'md'} mb={'sm'} onPress={call} icon='logo-firebase'>
+					{t("memento:create-deck")}
+				</FancyButton>
+
+				{selectedDecks.length > 0 && (
+					<TView mt={'md'} style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+						<FancyButton
+							backgroundColor='red'
+							onPress={deleteSelectedDecks}
+							mb={'sm'}
+							style={{ flex: 1 }}
+						>
+							Delete Selected Deck
+						</FancyButton>
+
+						<FancyButton
+							backgroundColor='blue'
+							onPress={cancelSelection}
+							style={{ flex: 1 }}
+						>
+							Cancel
+						</FancyButton>
+					</TView>
+				)}
+
+				<For each={decks}>
+					{deck =>
+						<DeckDisplay
+							key={deck.id}
+							deck={deck.data}
+							id={deck.id}
+							isSelected={selectedDecks.some(selected => selected.name === deck.data.name)}
+							toggleSelection={toggleDeckSelection}
+							onLongPress={enterSelectionMode}
+							selectionMode={selectionMode}
+						/>}
+				</For>
+			</TScrollView>
+		</>
+	);
 };
 
 export default DeckScreen;
@@ -192,32 +204,32 @@ export default DeckScreen;
  * @returns deck display component
  */
 export const DeckDisplay: ReactComponent<{ deck: Memento.Deck, id: string; isSelected: boolean; toggleSelection: (deck: Memento.Deck) => void; onLongPress: () => void; selectionMode: boolean; }> = ({ deck, id, isSelected, toggleSelection, onLongPress, selectionMode }) => {
-    const handlePress = () => {
-        if (!selectionMode) {
-            router.push(`/deck/${id}`);
-        } else {
-            toggleSelection(deck);  // Only toggle selection if we're in selection mode
-        }
-    };
+	const handlePress = () => {
+		if (!selectionMode) {
+			router.push(`/deck/${id}`);
+		} else {
+			toggleSelection(deck);  // Only toggle selection if we're in selection mode
+		}
+	};
 
-    return (
-        <TTouchableOpacity bb={0}
-            onLongPress={() => {
-                onLongPress();
-                toggleSelection(deck);
-            }}
-            onPress={handlePress}
-            m='md' mt={'sm'} mb={'sm'} p='lg'
-            backgroundColor={isSelected ? 'rosewater' : 'base'}
-            borderColor='crust' radius='lg'
-        >
-            <TText bold>
-                {deck.name}
-            </TText>
-            <TText mb='md' color='subtext0' size={'sm'}>
-                2h ago
-            </TText>
-            {isSelected && <TText color='green'>✓</TText>}
-        </TTouchableOpacity>
-    );
+	return (
+		<TTouchableOpacity bb={0}
+			onLongPress={() => {
+				onLongPress();
+				toggleSelection(deck);
+			}}
+			onPress={handlePress}
+			m='md' mt={'sm'} mb={'sm'} p='lg'
+			backgroundColor={isSelected ? 'rosewater' : 'base'}
+			borderColor='crust' radius='lg'
+		>
+			<TText bold>
+				{deck.name}
+			</TText>
+			<TText mb='md' color='subtext0' size={'sm'}>
+				2h ago
+			</TText>
+			{isSelected && <TText color='green'>✓</TText>}
+		</TTouchableOpacity>
+	);
 };

--- a/edweiss-app/components/core/modal/ModalContainer.tsx
+++ b/edweiss-app/components/core/modal/ModalContainer.tsx
@@ -1,4 +1,5 @@
 import ReactComponent from '@/constants/Component';
+import { useColor } from '@/hooks/theme/useThemeColor';
 
 import useBottomSheetBackHandler from '@/hooks/useBottomSheetBackHandler';
 import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
@@ -6,11 +7,11 @@ import { BottomSheetModalMethods } from '@gorhom/bottom-sheet/lib/typescript/typ
 import { ReactNode, useCallback } from 'react';
 
 const ModalContainer: ReactComponent<{ snapPoints?: (string | number)[], modalRef: React.RefObject<BottomSheetModalMethods>, children?: ReactNode; }> = (props) => {
-	//const backgroundColor = useColor("mantle");
-	//const handleIndicatorColor = useColor("base");
+	const backgroundColor = useColor("mantle");
+	const handleIndicatorColor = useColor("overlay0");
 
-	const backgroundColor = 'white';
-	const handleIndicatorColor = 'black';
+	// const backgroundColor = 'white';
+	// const handleIndicatorColor = 'black';
 
 	const { handleSheetPositionChange } = useBottomSheetBackHandler(props.modalRef);
 

--- a/edweiss-app/config/SyncStorage.ts
+++ b/edweiss-app/config/SyncStorage.ts
@@ -13,6 +13,7 @@ export class SyncStorageSingleton {
 	loading: boolean = true;
 	// listeners: Map<string, (data: unknown) => void> = new Map();
 	listeners: { key: string, callback: (data: any) => void }[] = [];
+	oneTapListeners: { key: string, callback: (data: any) => void }[] = []
 
 	init() {
 		if (this.loading == false)
@@ -42,6 +43,15 @@ export class SyncStorageSingleton {
 
 	removeListener<T>(listener: { key: string, callback: (data: T) => void }) {
 		this.listeners = this.listeners.filter(l => l != listener);
+	}
+
+	pushOneTapListener<T>(key: string, callback: (data: T | undefined) => void) {
+		const listener = {
+			key,
+			callback
+		};
+
+		this.oneTapListeners.push(listener);
 	}
 
 	get(key: string): any {
@@ -106,7 +116,9 @@ export class SyncStorageSingleton {
 	}
 
 	triggerListeners(key: string, data: any) {
-		this.listeners.filter(l => l.key === key).forEach(l => l.callback(data))
+		this.listeners.filter(l => l.key === key).forEach(l => l.callback(data));
+		this.oneTapListeners.filter(l => l.key === key).forEach(l => l.callback(data));
+		this.oneTapListeners = this.oneTapListeners.filter(l => l.key !== key);
 	}
 
 	getAllKeys(): string[] {

--- a/edweiss-app/hooks/firebase/firestore.ts
+++ b/edweiss-app/hooks/firebase/firestore.ts
@@ -1,7 +1,9 @@
-import { Collection, Collections, Document, DocumentData, DocumentOf, Query, callFunction, getDocument, getDocuments } from '@/config/firebase';
-import Memento from '@/model/memento';
+import SyncStorage from '@/config/SyncStorage';
+import { Collection, Document, DocumentData, DocumentOf, Query, getDocument, getDocuments } from '@/config/firebase';
+import { CallResult } from '@/model/functions';
+import generateUID from '@/utils/uid';
 import { doc, onSnapshot } from '@react-native-firebase/firestore';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useStoredState } from '../storage';
 
 export function useDoc<Type extends DocumentData>(collection: Collection<Type>, id: string): Document<Type> | undefined {
@@ -134,79 +136,233 @@ export function useCachedDocs<Type extends DocumentData>(key: string, query: Que
 	return documents;
 }
 
+type SyncCallback = (id: string) => void;
+
 export interface RepositoryHandler<T extends DocumentData> {
-	deleteDocument: (id: string) => void,
-	changeDocument: (id: string, newData: Partial<T>) => void,
-	addDocument: (t: T) => void
+	readonly addDocument: (data: T, idSupplier: Promise<CallResult<{ id: string }, unknown>> | undefined) => void,
+	readonly modifyDocument: (id: string, data: Partial<T>, syncCallback: SyncCallback | undefined) => void,
+	readonly deleteDocument: (id: string, syncCallback: SyncCallback | undefined) => void
 }
 
-// export type RepositoryActions<T extends DocumentData> = {
-// 	[x in string]: RepositoryAction<T>
-// }
-
-// type RepositoryAction<T extends DocumentData> = (handler: RepositoryHandler<T>, ...args: any[]) => void;
+export interface RepositoryDocumentHandler<T extends DocumentData> {
+	readonly modify: (id: string, data: Partial<T>, syncCallback: SyncCallback | undefined) => void,
+	readonly delete: (id: string, syncCallback: SyncCallback | undefined) => void
+}
 
 export interface RepositoryDocument<Type> extends Document<Type> {
-	synced: boolean
+	syncedId: boolean
 }
 
-export function useRepository<Type extends DocumentData>(query: Query<Type>, deps?: React.DependencyList): [Document<Type>[] | undefined, RepositoryHandler<Type>] {
-	const [documents, setDocuments] = useState<Document<Type>[]>();
+export interface YetToSyncEvent {
+	fakeId: string,
+	callback: SyncCallback
+}
+
+const FakeIdLength = 16;
+
+type RepositoryKey = string;
+
+export function useRepository<Type extends DocumentData>(repositoryKey: RepositoryKey, query: Query<Type>): [RepositoryDocument<Type>[] | undefined, RepositoryHandler<Type>] {
+	const [documents, setDocuments, refreshRepository] = useStoredState<RepositoryDocument<Type>[] | undefined>(`repo:${repositoryKey}`, undefined);
+	const yetToSyncEvents = useRef<YetToSyncEvent[]>([]);
 
 	useEffect(() => {
-		getDocuments(query).then(docs => setDocuments(docs));
+		(async () => {
+			const fetchedDocuments = await getDocuments(query);
+			setDocuments(fetchedDocuments.map(doc => ({ ...doc, syncedId: true })));
+		})();
+	}, []);
 
-		let firstTime = true;
-		const unsubscribe = query.onSnapshot(querySnapshot => {
-			if (firstTime == true) {
-				firstTime = false;
-				return;
+	useEffect(() => {
+		const unsubscribe = SyncStorage.addListener<RepositoryDocument<Type>[] | undefined>(`repo:${repositoryKey}`, (value) => {
+			value?.forEach(doc => {
+				if (doc.syncedId) {
+					yetToSyncEvents.current.filter(event => event.fakeId == doc.id).forEach(event => event.callback(doc.id));
+					yetToSyncEvents.current = yetToSyncEvents.current.filter(event => event.fakeId != doc.id);
+				}
+			})
+			refreshRepository();
+		});
+		return unsubscribe;
+	}, []);
+
+	const addDocument = useCallback((data: Type, idSupplier: Promise<CallResult<{ id: string }, unknown>> | undefined) => {
+		const fakeId = generateUID(FakeIdLength);
+
+		setDocuments(documents => {
+			const toAdd: RepositoryDocument<Type> = {
+				id: fakeId,
+				data,
+				syncedId: false
+			};
+
+			return documents ? [...documents, toAdd] : [toAdd];
+		});
+
+		if (idSupplier) {
+			idSupplier.then(res => {
+				if (res.status == 1) {
+					setDocuments(documents => {
+						const newDocuments = documents ? [...documents] : [];
+						const doc = newDocuments.find(doc => doc.id == fakeId);
+
+						if (doc) {
+							doc.id = res.data.id;
+							doc.syncedId = true;
+						} else {
+							newDocuments.push({
+								id: res.data.id,
+								data,
+								syncedId: true
+							});
+						}
+
+						yetToSyncEvents.current.filter(event => event.fakeId == fakeId).forEach(event => {
+							event.callback(res.data.id);
+						});
+						yetToSyncEvents.current = yetToSyncEvents.current.filter(event => event.fakeId != fakeId);
+
+						return newDocuments;
+					});
+				} else {
+					deleteDocument(fakeId, undefined);
+				}
+			});
+		}
+	}, []);
+
+	const modifyDocument = useCallback((id: string, newData: Partial<Type>, syncCallback: SyncCallback | undefined) => {
+		setDocuments(documents => {
+			if (documents) {
+				const newDocuments = [...documents];
+				const doc = newDocuments.find(doc => doc.id == id);
+				if (doc) {
+					doc.data = { ...doc.data, newData };
+					if (syncCallback) {
+						if (doc.syncedId) {
+							syncCallback(doc.id);
+						} else {
+							yetToSyncEvents.current.push({
+								fakeId: doc.id,
+								callback: syncCallback
+							});
+						}
+					}
+				}
+				return newDocuments;
 			}
+		});
 
-			setDocuments(querySnapshot.docs.map(DocumentOf<Type>));
-		}, error => {
-			console.log(`Snapshot Error: ${error}`)
-		})
-		return unsubscribe
-	}, deps || []);
+	}, []);
+
+	const deleteDocument = useCallback((id: string, syncCallback: SyncCallback | undefined) => {
+		setDocuments(documents => {
+			if (documents) {
+				const newDocuments = [...documents];
+				const doc = newDocuments.find(doc => doc.id == id);
+
+				if (doc) {
+					newDocuments.splice(newDocuments.indexOf(doc), 1);
+
+					if (syncCallback) {
+						if (doc.syncedId) {
+							syncCallback(doc.id);
+						} else {
+							yetToSyncEvents.current.push({
+								fakeId: doc.id,
+								callback: syncCallback
+							});
+						}
+					}
+				}
+
+				return newDocuments;
+			}
+		});
+	}, []);
 
 	const handler: RepositoryHandler<Type> = useMemo(() => ({
-		addDocument(data) {
-			setDocuments(documents => {
-				const toAdd: RepositoryDocument<Type> = {
-					id: generateUID(8),
-					data,
-					synced: false
-				};
+		addDocument,
+		modifyDocument,
+		deleteDocument
+	}), []);
 
-				if (documents == undefined) {
-					return [toAdd];
-				} else {
-					return [...documents, toAdd];
+	return [documents, handler] as const;
+}
+
+export function useRepositoryDocument<Type extends DocumentData>(repositoryKey: RepositoryKey, collection: Collection<Type>, id: string): [RepositoryDocument<Type> | undefined, RepositoryDocumentHandler<Type>] {
+	const [repository, setRepository, refreshRepository] = useStoredState<RepositoryDocument<Type>[] | undefined>(`repo:${repositoryKey}`, undefined);
+	const yetToSyncEvents = useRef<YetToSyncEvent[]>([]);
+
+	const document = useMemo(() => {
+		return repository?.find(repo => repo.id == id);
+	}, [repository]);
+
+	useEffect(() => {
+		if (repository == undefined)
+			console.log("You might have got the `repositoryKey` wrong. Check it again.");
+
+		const unsubscribe = SyncStorage.addListener<RepositoryDocument<Type>[] | undefined>(`repo:${repositoryKey}`, (value) => {
+			value?.forEach(doc => {
+				if (doc.syncedId) {
+					yetToSyncEvents.current.filter(event => event.fakeId == doc.id).forEach(event => event.callback(doc.id));
+					yetToSyncEvents.current = yetToSyncEvents.current.filter(event => event.fakeId != doc.id);
+				}
+			})
+			refreshRepository();
+		});
+		return unsubscribe;
+	}, []);
+
+	const handler: RepositoryDocumentHandler<Type> = useMemo(() => ({
+		modify(id, newData, syncCallback) {
+			setRepository(documents => {
+				if (documents) {
+					const newDocuments = [...documents];
+					const doc = newDocuments.find(doc => doc.id == id);
+					if (doc) {
+						doc.data = { ...doc.data, newData };
+						if (syncCallback) {
+							if (doc.syncedId) {
+								syncCallback(doc.id);
+							} else {
+								yetToSyncEvents.current.push({
+									fakeId: doc.id,
+									callback: syncCallback
+								});
+							}
+						}
+					}
+					return newDocuments;
 				}
 			});
 		},
-		changeDocument(id, newData) {
+		delete(id, syncCallback) {
+			setRepository(documents => {
+				if (documents) {
+					const newDocuments = [...documents];
+					const doc = newDocuments.find(doc => doc.id == id);
 
+					if (doc) {
+						newDocuments.splice(newDocuments.indexOf(doc), 1);
+
+						if (syncCallback) {
+							if (doc.syncedId) {
+								syncCallback(doc.id);
+							} else {
+								yetToSyncEvents.current.push({
+									fakeId: doc.id,
+									callback: syncCallback
+								});
+							}
+						}
+					}
+
+					return newDocuments;
+				}
+			});
 		},
-		deleteDocument(id) {
+	}), []);
 
-		},
-	}), deps || []);
-
-	return [documents, handler];
-}
-
-function generateUID(len: number): string {
-	return "";
-}
-
-const [documents, handler] = useRepository(Collections.deck);
-
-const addDeck = async (deck: Memento.Deck) => {
-	handler.addDocument(deck);
-	const res = await callFunction(Memento.Functions.createDeck, { deck });
-	if (res.status == 0) {
-
-	}
+	return [document, handler] as const;
 }

--- a/edweiss-app/hooks/repository.tsx
+++ b/edweiss-app/hooks/repository.tsx
@@ -1,0 +1,273 @@
+import { Document, DocumentData, Query, getDocuments } from '@/config/firebase';
+import { CallResult } from '@/model/functions';
+import generateUID from '@/utils/uid';
+import { Stack } from 'expo-router';
+import React, { ReactNode, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { useStoredState } from './storage';
+
+// export type Repository<Type> = Document<Type>[];
+
+export interface RepositorySignature<T extends DocumentData> {
+	readonly key: string,
+	readonly context: React.Context<Repository<T>>
+}
+
+export interface RepositoryDocument<Type> extends Document<Type> {
+	syncedId: boolean,
+	readonly fakeId?: string
+}
+
+export interface RepositoryHandler<T extends DocumentData> {
+	readonly addDocument: (data: T, idSupplier: Promise<CallResult<{ id: string }, unknown>>) => void,
+	readonly modifyDocument: (id: string, data: Partial<T>, syncCallback: MonoSyncCallback | undefined) => void,
+	readonly deleteDocument: (id: string, syncCallback: MonoSyncCallback | undefined) => void,
+	readonly deleteDocuments: (ids: string[], syncCallback: ((ids: string[]) => void) | undefined) => void,
+}
+
+export type Repository<Type extends DocumentData> = [RepositoryDocument<Type>[] | undefined, RepositoryHandler<Type>]
+
+type MonoSyncCallback = (id: string) => void;
+type MultiSyncCallback = (id: string[]) => void;
+
+export interface MonoYetToSyncEvent {
+	type: "mono",
+	fakeId: string,
+	callback: MonoSyncCallback
+}
+
+export interface MultiYetToSyncEvent {
+	type: "multi",
+	fakeIds: string[],
+	callback: MultiSyncCallback
+}
+
+export type YetToSyncEvent = MonoYetToSyncEvent | MultiYetToSyncEvent;
+
+export function createRepository<T extends DocumentData>(key: string): RepositorySignature<T> {
+	return {
+		key, context: React.createContext<Repository<T>>([undefined, {
+			addDocument: () => console.log("No repository found. Check the guide on GitHub."),
+			modifyDocument: () => console.log("No repository found. Check the guide on GitHub."),
+			deleteDocument: () => console.log("No repository found. Check the guide on GitHub."),
+			deleteDocuments: () => console.log("No repository found. Check the guide on GitHub."),
+		}])
+	};
+}
+
+function collectTrueIds<T>(newDocuments: RepositoryDocument<T>[], fakeIds: string[]): string[] | undefined {
+	const trueIds: string[] = [];
+
+	for (let idIndex = 0; idIndex < fakeIds.length; idIndex++) {
+		const id = fakeIds[idIndex];
+		const doc = newDocuments.find(doc => doc.id == id || doc.fakeId == id);
+		if (doc) {
+			if (!doc.syncedId)
+				return undefined;
+
+			trueIds.push(doc.id);
+		} else return undefined;
+	}
+
+	return trueIds;
+}
+
+const FakeIdLength = 16;
+
+export function useInitialRepository<Type extends DocumentData>(signature: RepositorySignature<Type>, query: Query<Type>): Repository<Type> {
+	const [documents, setDocuments] = useStoredState<RepositoryDocument<Type>[] | undefined>(signature.key, undefined);
+	const yetToSyncEvents = useRef<YetToSyncEvent[]>([]);
+
+	useEffect(() => {
+		(async () => {
+			const fetchedDocuments = await getDocuments(query);
+			setDocuments(fetchedDocuments.map(doc => ({ ...doc, syncedId: true })));
+		})();
+	}, []);
+
+	const addDocument = useCallback((data: Type, idSupplier: Promise<CallResult<{ id: string }, unknown>>) => {
+		const fakeId = generateUID(FakeIdLength);
+
+		setDocuments(documents => {
+			const toAdd: RepositoryDocument<Type> = {
+				id: fakeId,
+				fakeId,
+				data,
+				syncedId: false
+			};
+
+			return documents ? [...documents, toAdd] : [toAdd];
+		});
+
+		idSupplier.then(res => {
+			if (res.status == 1) {
+				setDocuments(documents => {
+					const newDocuments = documents ? [...documents] : [];
+					const doc = newDocuments.find(doc => doc.id == fakeId);
+
+					if (doc) {
+						doc.id = res.data.id;
+						doc.syncedId = true;
+					} else {
+						newDocuments.push({
+							id: res.data.id,
+							data,
+							syncedId: true
+						});
+					}
+
+					let toRemove: YetToSyncEvent[] = [];
+
+					for (let index = 0; index < yetToSyncEvents.current.length; index++) {
+						const event = yetToSyncEvents.current[index];
+
+						if (event.type == "mono") {
+							if (event.fakeId == fakeId) {
+								event.callback(res.data.id);
+								toRemove.push(event);
+							}
+						} else if (event.type == "multi") {
+							const trueIds = collectTrueIds(newDocuments, event.fakeIds);
+							if (trueIds != undefined) {
+								event.callback(trueIds);
+								toRemove.push(event);
+							}
+						}
+					}
+
+					// yetToSyncEvents.current.filter(event => event.fakeId == fakeId).forEach(event => event.callback(res.data.id));
+
+					yetToSyncEvents.current = yetToSyncEvents.current.filter(event => !toRemove.includes(event));
+
+					return newDocuments;
+				});
+			} else {
+				deleteDocument(fakeId, undefined);
+			}
+		});
+	}, []);
+
+	const modifyDocument = useCallback((id: string, newData: Partial<Type>, syncCallback: MonoSyncCallback | undefined) => {
+		setDocuments(documents => {
+			if (documents) {
+				const newDocuments = [...documents];
+				const doc = newDocuments.find(doc => doc.id == id || doc.fakeId == id);
+				if (doc) {
+					doc.data = { ...doc.data, ...newData };
+					if (syncCallback) {
+						if (doc.syncedId) {
+							syncCallback(doc.id);
+						} else {
+							yetToSyncEvents.current.push({
+								type: "mono",
+								fakeId: doc.id,
+								callback: syncCallback
+							});
+						}
+					}
+				}
+				return newDocuments;
+			}
+		});
+
+	}, []);
+
+	const deleteDocument = useCallback((id: string, syncCallback: MonoSyncCallback | undefined) => {
+		setDocuments(documents => {
+			if (documents) {
+				const newDocuments = [...documents];
+				const doc = newDocuments.find(doc => doc.id == id || doc.fakeId == id);
+
+				if (doc) {
+					newDocuments.splice(newDocuments.indexOf(doc), 1);
+
+					if (syncCallback) {
+						if (doc.syncedId) {
+							syncCallback(doc.id);
+						} else {
+							yetToSyncEvents.current.push({
+								type: "mono",
+								fakeId: doc.id,
+								callback: syncCallback
+							});
+						}
+					}
+				}
+
+				return newDocuments;
+			}
+		});
+	}, []);
+
+	const deleteDocuments = useCallback((ids: string[], syncCallback: ((ids: string[]) => void) | undefined) => {
+		setDocuments(documents => {
+			if (documents) {
+				const newDocuments = [...documents];
+
+				ids.forEach(id => {
+					const doc = newDocuments.find(doc => doc.id == id || doc.fakeId == id);
+					if (doc != undefined)
+						newDocuments.splice(newDocuments.indexOf(doc), 1);
+				});
+
+				if (syncCallback) {
+					const trueIds = collectTrueIds(documents, ids);
+					// console.log(`True ids : ${trueIds}`);
+					// console.log(`Ids: ${ids}`);
+					// console.log(`Documents: ${JSON.stringify(documents.map(d => `${d.id} / ${d.fakeId}`))}`);
+					if (trueIds) {
+						syncCallback(trueIds);
+					} else {
+						yetToSyncEvents.current.push({
+							type: "multi",
+							fakeIds: ids,
+							callback: syncCallback
+						});
+					}
+				}
+
+				return newDocuments;
+			}
+		});
+	}, []);
+
+	const handler: RepositoryHandler<Type> = useMemo(() => ({
+		addDocument,
+		modifyDocument,
+		deleteDocument,
+		deleteDocuments
+	}), []);
+
+	return [documents, handler] as const;
+}
+
+export function useRepository<T extends DocumentData>({ context }: RepositorySignature<T>) {
+	return useContext(context);
+}
+
+export function useRepositoryDocument<T extends DocumentData>(id: string, signature: RepositorySignature<T>) {
+	const [repository, handler] = useRepository(signature);
+	if (repository == undefined)
+		return [undefined, handler] as const;
+	return [repository.find(repo => repo.id == id || repo.fakeId == id), handler] as const;
+}
+
+export function RepositoryLayout<T extends DocumentData>(props: { signature: RepositorySignature<T>, collection: Query<T> }) {
+	const repository = useInitialRepository(props.signature, props.collection);
+	const Context = props.signature.context;
+
+	return (
+		<Context.Provider value={repository}>
+			<Stack />
+		</Context.Provider>
+	)
+}
+
+export function RepositoryProvider<T extends DocumentData>(props: { children?: ReactNode, signature: RepositorySignature<T>, repository: Repository<T> }) {
+	const Context = props.signature.context;
+
+	return (
+		<Context.Provider value={props.repository}>
+			{props.children}
+		</Context.Provider>
+	)
+}

--- a/edweiss-app/hooks/repository.tsx
+++ b/edweiss-app/hooks/repository.tsx
@@ -78,10 +78,12 @@ export function useInitialRepository<Type extends DocumentData>(signature: Repos
 	const yetToSyncEvents = useRef<YetToSyncEvent[]>([]);
 
 	useEffect(() => {
-		(async () => {
+		const timeout = setTimeout(async () => {
 			const fetchedDocuments = await getDocuments(query);
 			setDocuments(fetchedDocuments.map(doc => ({ ...doc, syncedId: true })));
-		})();
+		}, documents == undefined ? 0 : 5000); // this is too take into account for quick back and fourth between screens
+
+		return () => clearTimeout(timeout);
 	}, []);
 
 	const addDocument = useCallback((data: Type, idSupplier: Promise<CallResult<{ id: string }, unknown>>) => {

--- a/edweiss-app/hooks/routeParameters.ts
+++ b/edweiss-app/hooks/routeParameters.ts
@@ -1,0 +1,23 @@
+import { Href, router, useLocalSearchParams } from 'expo-router';
+
+export interface ApplicationRouteParameters<T> {
+	path: Href<string>
+}
+
+export function useStringParameters(): { [x in string]: string } {
+	return useLocalSearchParams();
+}
+
+export function useRouteParameters<T>(_: ApplicationRouteParameters<T>): T {
+	const { params } = useLocalSearchParams();
+	return JSON.parse(params as string) as T;
+}
+
+export function pushWithParameters<T>(route: ApplicationRouteParameters<T>, params: T) {
+	router.push({
+		pathname: route.path as any,
+		params: {
+			params: JSON.stringify(params)
+		}
+	});
+}

--- a/edweiss-app/hooks/routeParameters.ts
+++ b/edweiss-app/hooks/routeParameters.ts
@@ -1,23 +1,48 @@
 import { Href, router, useLocalSearchParams } from 'expo-router';
+import { useMemo } from 'react';
 
-export interface ApplicationRouteParameters<T> {
+/**
+ * The application route type signature alongside its path.
+ * 
+ * Use with {@link useRouteParameters} and {@link pushWithParameters}.
+ */
+export interface ApplicationRouteSignature<T> {
 	path: Href<string>
 }
 
-export function useStringParameters(): { [x in string]: string } {
-	return useLocalSearchParams();
-}
-
-export function useRouteParameters<T>(_: ApplicationRouteParameters<T>): T {
+/**
+ * Parses the route parameters with {@link ApplicationRouteSignature} to deduce the type of the parameters.
+ * 
+ * Use {@link pushWithParameters} to push the right arguments.
+ * 
+ * @returns The parsed parameters.
+ */
+export function useRouteParameters<T>(_: ApplicationRouteSignature<T>): T {
 	const { params } = useLocalSearchParams();
-	return JSON.parse(params as string) as T;
+
+	const parsed = useMemo(() => JSON.parse(params as string) as T, []);
+
+	return parsed;
 }
 
-export function pushWithParameters<T>(route: ApplicationRouteParameters<T>, params: T) {
+/**
+ * Pushes type-safe arguments to the given route.
+ * 
+ * @param signature The pushed route. It also gives type-safe constraints to the arguments.
+ * @param params Arguments to push
+ */
+export function pushWithParameters<T>(signature: ApplicationRouteSignature<T>, params: T) {
 	router.push({
-		pathname: route.path as any,
+		pathname: signature.path as any,
 		params: {
 			params: JSON.stringify(params)
 		}
 	});
+}
+
+/**
+ * @returns `useLocalSearchParams()` but only with string parameters returned.
+ */
+export function useStringParameters(): { [x in string]: string } {
+	return useLocalSearchParams();
 }

--- a/edweiss-app/utils/uid.ts
+++ b/edweiss-app/utils/uid.ts
@@ -1,0 +1,19 @@
+
+export function predictiveUID(a: string, b: string, len: number) {
+	if (a.localeCompare(b)) {
+		return a.slice(0, len) + "" + b.slice(0, len);
+	} else {
+		return b.slice(0, len) + "" + a.slice(0, len);
+	}
+}
+
+export default function generateUID(length: number) {
+	const alphabet = "qwertyuiopasdfghjklzxcvbnQWERTYUIOPASDFGHJKLZXCVBN0123456789";
+	let res = "";
+
+	for (let i = 0; i < length; i++) {
+		res += alphabet.charAt(Math.floor(Math.random() * alphabet.length));
+	}
+
+	return res;
+}


### PR DESCRIPTION
Hello,

As you might have noticed in the main app, a lot of the CRUD operations (Create, Read, Update and Delete) are slow and feel clunky. This is because every operation goes as follows : First we use `callFunction` to update the state of the collections in the cloud, then the UI waits changes using variants of `useDynamicDocs`.
This is insanely inefficient and gives a rather poor user experience, as every single interaction feels laggy, making the whole app feel a bit cheap.

To remedy this, we will now use the `Repository`, a new way of handling changes in collections and synchronization with the Cloud. This makes every interaction instantaneous and gives a much much better user experience, while still assuring a 100% synchronization with the Cloud.

We will use @TuanDangNguyen2003's Memento as an example for the following.

## How to use it
### `Repository` setup
The `Repository` is simply a controlled collection. We add, update and remove documents from the `Repository` using a `handler`. A `Repository` also has a unique key, different from the collection path, that we use to store it locally.

In Memento, the primary collection is `decks` that are of type `Memento.Deck`, so we write the following :
```typescript
const DecksRepository = createRepository<Memento.Deck>("my-decks");
```
You can see here that `my-decks` is the unique key of this repository.

We are working in the `app/(app)/deck` directory and I want the all the pages that are inside of it to be able to access the `Repository` and manipulate it.
I will then create a new file `app/(app)/deck/_layout.tsx` that will simply propagate the whole repository to all the files inside the directory. I will also put the repository creation code there :
```typescript
export const DecksRepository = createRepository<Memento.Deck>("my-decks");

const MementoLayout: ApplicationLayout = () => {
    const { uid } = useAuth();
    const collection = CollectionOf<Memento.Deck>(`users/${uid}/decks`);
    return <RepositoryLayout repository={DecksRepository} collection={collection} />;
};

export default MementoLayout;

```
As you see in this example, I link the local repository `my-decks` to the user's deck collection in Firebase.

### Accessing the `Repository` inside the routes
There are two main hooks to access the repository from inside the routes :

The `useRepository` hook gives you access to all the documents in the `Repository` as well as the `handler`.
```typescript
const [decks, handler] = useRepository(DecksRepository);
```

The `useRepositoryDocument` hook directly gives you a specific document in the Repository, as well as the `handler`.
```typescript
const [deck, handler] = useRepositoryDocument(id, DecksRepository);
```

### Manipulating the `Repository` using the `handler`.
The `handler` is an object that gives you full control of the repository, while still assuring that everything is kept in sync with the Cloud.

#### Adding a document
To add new documents, we will use `handler.addDocument(data, idSupplier)`.
`idSupplier` here is expected to be a Firebase Cloud Function call (with `callFunction` of course) that, as a return value, has the `id` of the newly formed document.
```typescript
const deck = {
    name: deckName,
    cards: []
}

handler.addDocument(deck, callFunction(Memento.Functions.createDeck, { deck }));
```
We do **NOT** use the `await` keyword as we want it to stay a `Promise`.

These lines effectively allow us to *optimistically* update the UI without waiting for the function call to end. Of course if the function call fails, it reverts back and removes the document, but it should be a rare occurrence. If you use the `handler`, you're the one in charge to assure that **failing** is a very rare occurrence (by verifying the inputs before calling the function for example).

#### Modifying a document
To modify an existing document (like updating one of its fields), we will use `handler.modifyDocument(id, partialData, syncCallback)`.
For `partialData`, you only put the fields that you want to modify, everything else remains intact.
```typescript
const newDeckName = "My amazing deck";

handler.modifyDocument(deckId, {name: newDeckName}, (id) => {
    callFunction(Memento.Functions.updateDeck, { deckId: id, deck: {name: newDeckName} });
});
```
As you see in this example, `syncCallback` supplies you with the real `id` of the document. For technical reasons, you can't directly use `deckId` (or at least you won't have the guaranty that you modify what you think you're modifying, the full implementation is in `@/hooks/repository`).

#### Deleting a document
To delete a document, we will use `handler.deleteDocument(id, syncCallback)` :
```typescript
handler.deleteDocument(id, (id) => {
    callFunction(Memento.Functions.deleteDecks, { deckIds: [id] });
});
```
Or delete multiple documents with `handler.deleteDocuments(ids, syncCallback)` :
```typescript
handler.deleteDocuments(deckIds, (ids) => {
    callFunction(Memento.Functions.deleteDecks, { deckIds: ids });
});
```

## Other minor improvements
#### Type safe route parameters (`utils/routeParameters.ts`)
Are you tired of checking that `id` is a `string` a not a `string[]` when you use `useLocalSearchParams()` ? You can now use `useStringParameters()` instead ! (it does the same thing, but just has the right signature)

You can now also instantiate a generic `ApplicationRouteParameters<T>` to use with `pushWithParameters(routeParameters, params)` and `useRouteParameters(routeParameters)`. This gives you full type safety when you pass multiple parameters so that you can feel confident about your code ! This also removes trivial errors like renaming in one place but forgetting in another.
#### Common mocking namespaces
One of the ways testing is painful is to find the mocks for the components and functions we use, please checkout the most common mocks at `__test__/__mocks__`. They aren't that many for now but please feel free to add all the ones that you find yourself using often!