### PR TITLE
Live Question integration in STRC and broadcast to ST!

### DIFF
--- a/edweiss-app/__test__/app/(app)/lectures/remotecontrol/questionToSlide.test.tsx
+++ b/edweiss-app/__test__/app/(app)/lectures/remotecontrol/questionToSlide.test.tsx
@@ -1,0 +1,333 @@
+import QuestionToSlideScreen from '@/app/(app)/lectures/remotecontrol/questionToSlide';
+import TView from '@/components/core/containers/TView';
+import { useAuth } from '@/contexts/auth';
+import { useUser } from '@/contexts/user';
+import { useDynamicDocs, usePrefetchedDynamicDoc } from '@/hooks/firebase/firestore';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { Timestamp } from '@react-native-firebase/firestore/lib/modular/Timestamp';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { useLocalSearchParams } from 'expo-router';
+import React from 'react';
+import { TextProps, TouchableOpacityProps, ViewProps } from 'react-native';
+
+
+// Mock data for `usePrefetchedDynamicDoc` with any lecture event
+const mockLectureData = {
+    data: {
+        pdfUri: 'mocked-uri',
+        audioTranscript: {},
+        event: {
+            id: "",
+            type: "invalid",
+        }
+    },
+};
+
+
+// Mock data for `usePrefetchedDynamicDoc` with any lecture event
+const mockLectureData2 = {
+    data: {
+        pdfUri: 'mocked-uri',
+        audioTranscript: {},
+        event: {
+            id: "1",
+            type: "question",
+        }
+    },
+};
+
+
+// Mock SyncStorage module
+jest.mock('@/config/SyncStorage', () => ({
+    init: jest.fn().mockResolvedValueOnce(undefined), // Mock the init method
+    get: jest.fn(),
+    set: jest.fn(),
+    // Mock other methods
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    getAllKeys: jest.fn().mockResolvedValue(['key1', 'key2']),  // Mocking `getAllKeys`
+    multiGet: jest.fn().mockResolvedValue([['key1', 'value1'], ['key2', 'value2']]),  // Mocking `multiGet`
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+}));
+// Mock data for `useDynamicDocs`
+const mockQuestionData = [
+    {
+        id: '1',
+        data: {
+            text: 'Test Question 1',
+            anonym: false,
+            userID: 'user1',
+            likes: 5,
+            username: 'User1',
+            postedTime: Timestamp.now(), // Include postedTime as an ISO string
+            answered: false,
+        },
+    },
+    {
+        id: '2',
+        data: {
+            text: 'Test Question 2',
+            anonym: true,
+            userID: 'mock-uid',
+            likes: 3,
+            username: '',
+            postedTime: Timestamp.now(), // Include postedTime as an ISO string
+            answered: false,
+        },
+    },
+];
+
+// `t` to return the key as the translation
+jest.mock('@/config/i18config', () => ({
+    __esModule: true,
+    default: jest.fn((key) => key),
+}));
+
+jest.mock('@/hooks/useListenToMessages', () => jest.fn());
+
+// Expo router
+jest.mock('expo-router', () => ({
+    router: { push: jest.fn() },
+    Stack: {
+        Screen: jest.fn(({ options }) => (
+            <>{options.title}</>
+        )),
+    },
+    useLocalSearchParams: jest.fn(() => ({ courseNameString: 'testCourse', lectureIdString: 'testLectureId' }))
+}));
+
+// Firebase Messaging to avoid NativeEventEmitter errors
+jest.mock('@react-native-firebase/messaging', () => ({
+    __esModule: true,
+    default: jest.fn(() => ({
+        onMessage: jest.fn(),
+        onNotificationOpenedApp: jest.fn(),
+        getInitialNotification: jest.fn(),
+    })),
+}));
+
+// Mock for react-native-pdf
+jest.mock('react-native-pdf', () => 'Pdf');
+
+// Mock for react-native-blob-util to avoid NativeEventEmitter issues
+jest.mock('react-native-blob-util', () => ({
+    fs: {
+        dirs: {
+            DocumentDir: '/mocked/document/dir',
+            CacheDir: '/mocked/cache/dir',
+        },
+        exists: jest.fn(),
+        readFile: jest.fn(),
+        unlink: jest.fn(),
+    },
+    config: jest.fn(),
+    session: jest.fn(),
+}));
+
+jest.mock('@react-native-firebase/storage', () => ({
+    ref: jest.fn(() => ({
+        getDownloadURL: jest.fn(() => Promise.resolve('https://example.com/test.pdf')), // Ensure it's here
+        putFile: jest.fn(() => Promise.resolve({ state: 'success' })),
+    })),
+}));
+
+// Firebase mock
+jest.mock('@/config/firebase', () => ({
+    callFunction: jest.fn(),
+    CollectionOf: jest.fn((path: string) => `MockedCollection(${path})`), // Mocking CollectionOf to return a simple string or mock object
+    getDownloadURL: jest.fn(),
+}));
+
+jest.mock('@/hooks/firebase/firestore', () => ({
+    usePrefetchedDynamicDoc: jest.fn(),
+    useDynamicDocs: jest.fn(),
+}));
+
+jest.mock('expo-screen-orientation', () => ({
+    unlockAsync: jest.fn(),
+    lockAsync: jest.fn(),
+    addOrientationChangeListener: jest.fn(),
+    removeOrientationChangeListener: jest.fn(),
+    Orientation: {
+        PORTRAIT_UP: 'PORTRAIT_UP',  // Correctly mock the values for portrait
+        LANDSCAPE_LEFT: 'LANDSCAPE_LEFT',
+        LANDSCAPE_RIGHT: 'LANDSCAPE_RIGHT',
+        PORTRAIT_DOWN: 'PORTRAIT_DOWN',
+    },
+    OrientationLock: {
+        LANDSCAPE: 'LANDSCAPE',  // Define the LANDSCAPE value here
+        PORTRAIT: 'PORTRAIT',    // Mock other necessary values if needed
+    },
+}));
+
+jest.mock('@react-native-firebase/auth', () => ({
+    // Mock Firebase auth methods you use in your component
+    signInWithCredential: jest.fn(() => Promise.resolve({ user: { uid: 'firebase-test-uid', email: 'firebase-test@example.com' } })),
+    signOut: jest.fn(() => Promise.resolve()),
+    currentUser: { uid: 'firebase-test-uid', email: 'firebase-test@example.com' },
+}));
+
+jest.mock('@react-native-firebase/firestore', () => {
+    const mockCollection = jest.fn(() => ({
+        doc: jest.fn(() => ({
+            set: jest.fn(() => Promise.resolve()),
+            get: jest.fn(() => Promise.resolve({ exists: true, data: () => ({ field: 'value' }) })),
+        })),
+    }));
+
+    // Ensure firestore is mocked as both a function and an object with methods
+    return {
+        __esModule: true,
+        default: jest.fn(() => ({
+            collection: mockCollection,
+        })),
+        collection: mockCollection
+    };
+});
+
+// Mock Firebase Functions
+jest.mock('@react-native-firebase/functions', () => ({
+    httpsCallable: jest.fn(() => () => Promise.resolve({ data: 'function response' })),
+}));
+
+jest.mock('@/contexts/auth', () => ({
+    useAuth: jest.fn(),                 // mock authentication
+}));
+
+jest.mock('react-native/Libraries/Settings/Settings', () => ({
+    get: jest.fn(),
+    set: jest.fn(),
+}));
+
+
+// Application Route
+jest.mock('@/constants/Component', () => ({
+    ApplicationRoute: jest.fn(),
+}));
+
+jest.mock('@/utils/time', () => ({
+    Time: {
+        fromDate: jest.fn(),
+    },
+}));
+
+jest.mock('@/components/core/containers/TView.tsx', () => {
+    const { View } = require('react-native');
+    return (props: ViewProps) => <View {...props} />;
+});
+jest.mock('@/components/core/TText.tsx', () => {
+    const { Text } = require('react-native');
+    return (props: TextProps) => <Text {...props} />;
+});
+jest.mock('@/components/core/containers/TTouchableOpacity.tsx', () => {
+    const { TouchableOpacity, View } = require('react-native');
+    return (props: React.PropsWithChildren<TouchableOpacityProps>) => (
+        <TouchableOpacity {...props}>
+            <View>{props.children}</View>
+        </TouchableOpacity>
+    );
+});
+
+jest.doMock('react-native-gesture-handler', () => {
+    return {
+        Swipeable: ({ onSwipeableOpen, children }: { onSwipeableOpen: Function, children: React.ReactNode; }) => {
+            return (
+                <TView
+                    data-testid="swipe-component"
+                    onTouchStart={() => {
+                        if (onSwipeableOpen) {
+                            onSwipeableOpen('right'); // Simuler un swipe à droite
+                        }
+                    }}
+                >
+                    {children}
+                </TView>
+            );
+        }
+    };
+});
+
+// Mock for @expo/vector-icons to render a div with accessibility label
+jest.mock('@expo/vector-icons', () => {
+    const React = require('react');
+    return {
+        Ionicons: ({ name, onPress, ...props }: { name: string, onPress?: () => void }) => (
+            <div {...props} onClick={onPress} data-testid={name} aria-label={name} />
+        ),
+    };
+});
+jest.mock('@/contexts/auth', () => ({
+    useAuth: jest.fn(),
+}));
+jest.mock('react-native-toast-message', () => ({
+    show: jest.fn(),
+}));
+
+// Mock the useUser hook
+jest.mock('@/contexts/user', () => ({
+    useUser: jest.fn(), // Mock the hook
+}));
+
+// BottomSheet to detect modal appearance
+jest.mock('@gorhom/bottom-sheet', () => ({
+    BottomSheetModal: jest.fn(({ present }) => (
+        <div>{present}</div>
+    )),
+}));
+
+describe('Question To Slide Test Suites', () => {
+
+    let modalRef: React.RefObject<BottomSheetModal>;
+
+    beforeEach(() => {
+        modalRef = {
+            current: {
+                present: jest.fn(),
+                dismiss: jest.fn(),
+                snapToIndex: jest.fn(),
+                snapToPosition: jest.fn(),
+                expand: jest.fn(),
+                collapse: jest.fn(),
+                close: jest.fn(),
+                forceClose: jest.fn(),
+            }
+        };
+
+        jest.clearAllMocks();
+        (usePrefetchedDynamicDoc as jest.Mock).mockReturnValue([mockLectureData2]); // Mocking `usePrefetchedDynamicDoc` with minimal data
+        (useDynamicDocs as jest.Mock).mockReturnValue(mockQuestionData); // Mocking `useDynamicDocs` with minimal question data
+        (useAuth as jest.Mock).mockReturnValue({ uid: 'mock-uid', });
+        (useUser as jest.Mock).mockReturnValue({ user: { name: 'Test User', }, });
+        (useLocalSearchParams as jest.Mock).mockReturnValue({ courseNameString: 'testCourse', lectureIdString: 'testLectureId' });
+    });
+
+
+
+    it('renders loading indicator when lectureDoc is not available', () => {
+        (usePrefetchedDynamicDoc as jest.Mock).mockReturnValue([undefined]);
+        render(<QuestionToSlideScreen />);
+        expect(screen.getByTestId('quest-slide-activity-indicator')).toBeTruthy();
+    });
+
+    it('renders questions when data is available', () => {
+        render(<QuestionToSlideScreen />);
+        expect(screen.getByText('Test Question 1')).toBeTruthy();
+        expect(screen.getByText('Test Question 2')).toBeTruthy();
+    });
+
+    it('opens modal when question is pressed', () => {
+        render(<QuestionToSlideScreen />);
+        const question = screen.getByText('Test Question 1');
+        fireEvent.press(question);
+        expect(BottomSheetModal).toHaveBeenCalled();
+    });
+
+    it('displays empty state when no questions are available', () => {
+        (useDynamicDocs as jest.Mock).mockReturnValue([]);
+        render(<QuestionToSlideScreen />);
+        expect(screen.getByText('showtime:empty_question')).toBeTruthy();
+    });
+});

--- a/edweiss-app/__test__/components/lectures/remotecontrol/abstractRmtCtl.test.tsx
+++ b/edweiss-app/__test__/components/lectures/remotecontrol/abstractRmtCtl.test.tsx
@@ -437,7 +437,7 @@ describe('AbstractRmtCrl Component', () => {
         });
     });
 
-    test('shows toast when Audiance Questions button is pressed', () => {
+    test('go to audience live question manager when it button is pressed', () => {
         const { getByTestId } = render(
             <AbstractRmtCrl
                 handleRight={handleRightMock}
@@ -455,10 +455,14 @@ describe('AbstractRmtCrl Component', () => {
         );
 
         fireEvent.press(getByTestId('strc-chat-button'));
-        expect(Toast.show).toHaveBeenCalledWith({
-            type: 'success',
-            text1: 'The Audiance  Questions',
-            text2: 'Implementation comes soon'
+        expect(router.push).toHaveBeenCalledWith({
+            pathname: '/(app)/lectures/remotecontrol/questionToSlide',
+            params: {
+                courseNameString,
+                lectureIdString,
+                currentPageString: curPageProvided.toString(),
+                totalPageString: totPageProvided.toString(),
+            },
         });
     });
 

--- a/edweiss-app/__test__/components/lectures/remotecontrol/modal.test.tsx
+++ b/edweiss-app/__test__/components/lectures/remotecontrol/modal.test.tsx
@@ -9,7 +9,7 @@
 // --------------- Import Modules & Components ----------------
 // ------------------------------------------------------------
 
-import { LangSelectModal, TimerSettingModal } from '@/components/lectures/remotecontrol/modal';
+import { LangSelectModal, QuestionBroadcastModal, TimerSettingModal } from '@/components/lectures/remotecontrol/modal';
 import LectureDisplay from '@/model/lectures/lectureDoc';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import { fireEvent, render } from '@testing-library/react-native';
@@ -393,3 +393,67 @@ describe('TimerSettingModal', () => {
         expect(mockSetTimer).not.toHaveBeenCalled();
     });
 });
+
+
+// ------------------------------------------------------------
+// -----      Question Broadcast Modal Test Suites       ------
+// ------------------------------------------------------------
+
+describe('QuestionBroadcastModal', () => {
+    const mockModalRef = { current: null };
+    const mockSetBroadcasted = jest.fn();
+    const mockOnClose = jest.fn();
+
+    const renderModal = (props = {}) =>
+        render(
+            <QuestionBroadcastModal
+                modalRef={mockModalRef}
+                id="1"
+                courseId="course1"
+                lectureId="lecture1"
+                question="Sample question?"
+                username="John Doe"
+                likes={5}
+                broadcasted=""
+                setBroadcasted={mockSetBroadcasted}
+                onClose={mockOnClose}
+                {...props}
+            />
+        );
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('renders correctly', () => {
+        const { getByTestId, getByText } = renderModal();
+        expect(getByText('John Doe')).toBeTruthy();
+        expect(getByText('5')).toBeTruthy();
+        expect(getByTestId('brod-quest-ans-button')).toBeTruthy();
+        expect(getByTestId('brod-quest-close-button')).toBeTruthy();
+    });
+
+    test('calls handleQuestionBroadcast when broadcast button is pressed', () => {
+        const { getByTestId } = renderModal();
+        const broadcastButton = getByTestId('brod-quest-ans-button');
+        fireEvent.press(broadcastButton);
+        expect(mockOnClose).toHaveBeenCalled();
+        expect(mockSetBroadcasted).toHaveBeenCalledWith("1");
+    });
+
+    test('calls handleQuestionBroadcast when broadcast button is pressed again to mark as answered', () => {
+        const { getByTestId } = renderModal({ broadcasted: "1" });
+        const broadcastButton = getByTestId('brod-quest-ans-button');
+        fireEvent.press(broadcastButton);
+        expect(mockOnClose).toHaveBeenCalled();
+        expect(mockSetBroadcasted).toHaveBeenCalledWith("");
+    });
+
+    test('calls onClose when the close button is pressed', () => {
+        const { getByTestId } = renderModal();
+        const closeButton = getByTestId('brod-quest-close-button');
+        fireEvent.press(closeButton);
+        expect(mockOnClose).toHaveBeenCalled();
+    });
+});
+

--- a/edweiss-app/__test__/showtime/LectureScreen.test.tsx
+++ b/edweiss-app/__test__/showtime/LectureScreen.test.tsx
@@ -15,11 +15,28 @@ import { TextProps, TouchableOpacityProps, ViewProps } from 'react-native';
 import Toast from 'react-native-toast-message';
 
 
-// Mock data for `usePrefetchedDynamicDoc`
+// Mock data for `usePrefetchedDynamicDoc` with any lecture event
 const mockLectureData = {
     data: {
         pdfUri: 'mocked-uri',
         audioTranscript: {},
+        event: {
+            id: "",
+            type: "invalid",
+        }
+    },
+};
+
+
+// Mock data for `usePrefetchedDynamicDoc` with any lecture event
+const mockLectureData2 = {
+    data: {
+        pdfUri: 'mocked-uri',
+        audioTranscript: {},
+        event: {
+            id: "1",
+            type: "question",
+        }
     },
 };
 
@@ -50,6 +67,7 @@ const mockQuestionData = [
             likes: 5,
             username: 'User1',
             postedTime: Timestamp.now(), // Include postedTime as an ISO string
+            answered: false,
         },
     },
     {
@@ -61,6 +79,7 @@ const mockQuestionData = [
             likes: 3,
             username: '',
             postedTime: Timestamp.now(), // Include postedTime as an ISO string
+            answered: false,
         },
     },
 ];
@@ -522,3 +541,35 @@ describe('LectureScreen Component', () => {
 });
 
 
+describe('LectureScreen Component Broadcasting Question to audiance', () => {
+
+    let modalRef: React.RefObject<BottomSheetModal>;
+
+    beforeEach(() => {
+        modalRef = {
+            current: {
+                present: jest.fn(),
+                dismiss: jest.fn(),
+                snapToIndex: jest.fn(),
+                snapToPosition: jest.fn(),
+                expand: jest.fn(),
+                collapse: jest.fn(),
+                close: jest.fn(),
+                forceClose: jest.fn(),
+            }
+        };
+
+        jest.clearAllMocks();
+        (usePrefetchedDynamicDoc as jest.Mock).mockReturnValue([mockLectureData2]); // Mocking `usePrefetchedDynamicDoc` with minimal data
+        (useDynamicDocs as jest.Mock).mockReturnValue(mockQuestionData); // Mocking `useDynamicDocs` with minimal question data
+        (useAuth as jest.Mock).mockReturnValue({ uid: 'mock-uid', });
+        (useUser as jest.Mock).mockReturnValue({ user: { name: 'Test User', }, });
+    });
+
+    it('display the correct current question on the screen', () => {
+        const { rerender } = render(<LectureScreen />);
+        rerender(<LectureScreen />);
+        expect(screen.getByText('« Test Question 1 »')).toBeTruthy();
+    });
+
+});

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -1,0 +1,47 @@
+/**
+ * @file question.tsx
+ * @description Main screen for displaying and managing the to do list in the edweiss app
+ * @author Adamm Alaoui
+ */
+
+// ------------------------------------------------------------
+// --------------- Import Modules & Components ----------------
+// ------------------------------------------------------------
+
+import TView from '@/components/core/containers/TView';
+import RouteHeader from '@/components/core/header/RouteHeader';
+import TText from '@/components/core/TText';
+import t from '@/config/i18config';
+import { ApplicationRoute } from '@/constants/Component';
+import React from 'react';
+
+
+
+// ------------------------------------------------------------
+// -------------------  Main To do list Screen  ---------------
+// ------------------------------------------------------------
+
+const TodoListScreen: ApplicationRoute = () => {
+
+
+    return (
+        <>
+
+            <RouteHeader title={t(`showtime:question_slide_title`)} />
+
+            <TView
+                justifyContent="center"
+                alignItems="center"
+                flex={1}>
+                <TText>{t('showtime:empty_question')}</TText>
+                <TText>{t('showtime:empty_question_funny_1')}</TText>
+                <TText>{t('showtime:empty_question_funny_2')}</TText>
+            </TView>
+
+
+        </>
+    );
+};
+
+export default TodoListScreen;
+

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -70,6 +70,7 @@ const TodoListScreen: ApplicationRoute = () => {
     if (!lectureDoc) return <TActivityIndicator size={40} testID='quest-slide-activity-indicator' />;
     const currentLecture = lectureDoc.data;
     questionsDoc?.sort((a, b) => b.data.likes - a.data.likes) || []
+    const questionDocPending = questionsDoc?.filter(question => !question.data.answered) || [];
 
 
     // Handle sigle question
@@ -121,9 +122,9 @@ const TodoListScreen: ApplicationRoute = () => {
 
 
 
-            {questionsDoc ? (
+            {questionDocPending ? (
                 <TScrollView>
-                    <For each={questionsDoc}>
+                    <For each={questionDocPending}>
                         {(question, index) => <QuestionDisplay question={question} index={index} />}
                     </For>
                 </TScrollView>

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -68,9 +68,15 @@ const TodoListScreen: ApplicationRoute = () => {
 
     // Wait for lectureDoc to be available
     if (!lectureDoc) return <TActivityIndicator size={40} testID='quest-slide-activity-indicator' />;
-    const currentLecture = lectureDoc.data;
     questionsDoc?.sort((a, b) => b.data.likes - a.data.likes) || []
     const questionDocPending = questionsDoc?.filter(question => !question.data.answered) || [];
+    const currentLecture = lectureDoc.data;
+
+    if (broadcasted === "" && currentLecture.event && currentLecture.event.type === "question") {
+        setBroadcasted(currentLecture.event.id);
+    }
+    console.log("Current Event", currentLecture.event)
+
 
 
     // Handle sigle question

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -1,6 +1,7 @@
 /**
- * @file question.tsx
- * @description Main screen for displaying and managing the to do list in the edweiss app
+ * @file questionToDisplay.tsx
+ * @description Main screen for handling the live student questions
+ *              and broadcast it to showtime.
  * @author Adamm Alaoui
  */
 
@@ -8,35 +9,110 @@
 // --------------- Import Modules & Components ----------------
 // ------------------------------------------------------------
 
+import TScrollView from '@/components/core/containers/TScrollView';
 import TView from '@/components/core/containers/TView';
+import For from '@/components/core/For';
 import RouteHeader from '@/components/core/header/RouteHeader';
+import Icon from '@/components/core/Icon';
+import TActivityIndicator from '@/components/core/TActivityIndicator';
 import TText from '@/components/core/TText';
+import { CollectionOf, Document } from '@/config/firebase';
 import t from '@/config/i18config';
 import { ApplicationRoute } from '@/constants/Component';
+import { useDynamicDocs, usePrefetchedDynamicDoc } from '@/hooks/firebase/firestore';
+import LectureDisplay from '@/model/lectures/lectureDoc';
+import { useLocalSearchParams } from 'expo-router';
 import React from 'react';
 
-
+// Types
+type Lecture = LectureDisplay.Lecture;
+type Question = LectureDisplay.Question;
 
 // ------------------------------------------------------------
-// -------------------  Main To do list Screen  ---------------
+// --------------    Question To Slide Screen    --------------
 // ------------------------------------------------------------
 
 const TodoListScreen: ApplicationRoute = () => {
 
+    const { courseNameString, lectureIdString } = useLocalSearchParams();
+    const courseName = courseNameString as string;
+    const lectureId = lectureIdString as string;
+
+    const [lectureDoc] = usePrefetchedDynamicDoc(CollectionOf<Lecture>(`courses/${courseName}/lectures`), lectureId, undefined);
+    const questionsDoc = useDynamicDocs(CollectionOf<Question>(`courses/${courseName}/lectures/${lectureId}/questions`));
+
+    // Wait for lectureDoc to be available
+    if (!lectureDoc) return <TActivityIndicator size={40} testID='quest-slide-activity-indicator' />;
+    const currentLecture = lectureDoc.data;
+    questionsDoc?.sort((a, b) => b.data.likes - a.data.likes) || []
+
+
+    const QuestionDisplay: React.FC<{
+        question: Document<Question>;
+        index: number;
+    }> = ({ question, index }) => {
+        const { text, anonym, userID, likes, username } = question.data;
+        const id = question.id;
+
+        return (
+            <TView key={index}
+                backgroundColor='crust'
+                borderColor='surface2'
+                b={'xl'}
+                radius={'lg'}
+                flex={1}
+                flexDirection='column'
+                ml='sm' mr='sm'
+                mb='md'
+            >
+                <TView flexDirection='row' justifyContent='space-between' ml='md' mb='xs'>
+                    {/* Person status */}
+                    <TText size={'sm'} pl={2} pt={'sm'} color='text'>{anonym ? "Anonym" : username}</TText>
+
+                    {/* Likes Status */}
+                    <TView flexDirection='row' mt='sm' mr='sm'>
+                        <TText>{likes}</TText>
+                        <Icon size={'md'} name={likes === 0 ? 'heart-outline' : 'heart'} color='red' ml='xs' mt='xs'></Icon>
+                    </TView>
+                </TView>
+
+                <TView pr={'sm'} pl={'md'} pb={'sm'} flexDirection='row' justifyContent='space-between' alignItems='flex-start'>
+
+                    {/* Question Content */}
+                    <TText ml={10} color='overlay2'>{text}</TText>
+
+                    {/* Squash tle likes at the right most position */}
+                    <TView flex={1}></TView>
+
+
+                </TView>
+            </TView >
+        );
+    }
 
     return (
         <>
 
             <RouteHeader title={t(`showtime:question_slide_title`)} />
 
-            <TView
-                justifyContent="center"
-                alignItems="center"
-                flex={1}>
-                <TText>{t('showtime:empty_question')}</TText>
-                <TText>{t('showtime:empty_question_funny_1')}</TText>
-                <TText>{t('showtime:empty_question_funny_2')}</TText>
-            </TView>
+
+
+            {questionsDoc ? (
+                <TScrollView>
+                    <For each={questionsDoc}>
+                        {(question, index) => <QuestionDisplay question={question} index={index} />}
+                    </For>
+                </TScrollView>
+            ) : (
+                <TView
+                    justifyContent="center"
+                    alignItems="center"
+                    flex={1}>
+                    <TText>{t('showtime:empty_question')}</TText>
+                    <TText>{t('showtime:empty_question_funny_1')}</TText>
+                    <TText>{t('showtime:empty_question_funny_2')}</TText>
+                </TView>
+            )}
 
 
         </>

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -75,7 +75,6 @@ const TodoListScreen: ApplicationRoute = () => {
     if (broadcasted === "" && currentLecture.event && currentLecture.event.type === "question") {
         setBroadcasted(currentLecture.event.id);
     }
-    console.log("Current Event", currentLecture.event)
 
 
 
@@ -128,7 +127,7 @@ const TodoListScreen: ApplicationRoute = () => {
 
 
 
-            {questionDocPending ? (
+            {questionDocPending && questionDocPending.length > 0 ? (
                 <TScrollView>
                     <For each={questionDocPending}>
                         {(question, index) => <QuestionDisplay question={question} index={index} />}

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -139,7 +139,7 @@ const TodoListScreen: ApplicationRoute = () => {
             )}
 
             {/* Modal */}
-            <QuestionBroadcastModal modalRef={modalRefQuestionBroadcast} id={selID} question={selQuestion} likes={selLikes} username={selUsername} broadcasted={broadcasted} setBroadcasted={setBroadcasted} onClose={() => modalRefQuestionBroadcast.current?.close()} />
+            <QuestionBroadcastModal modalRef={modalRefQuestionBroadcast} id={selID} courseId={courseName} lectureId={lectureId} question={selQuestion} likes={selLikes} username={selUsername} broadcasted={broadcasted} setBroadcasted={setBroadcasted} onClose={() => modalRefQuestionBroadcast.current?.close()} />
         </>
     );
 };

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -38,7 +38,7 @@ type Question = LectureDisplay.Question;
 // --------------    Question To Slide Screen    --------------
 // ------------------------------------------------------------
 
-const TodoListScreen: ApplicationRoute = () => {
+const QuestionToSlideScreen: ApplicationRoute = () => {
     // Argument Processing
     const { courseNameString, lectureIdString } = useLocalSearchParams();
     const courseName = courseNameString as string;
@@ -150,5 +150,5 @@ const TodoListScreen: ApplicationRoute = () => {
     );
 };
 
-export default TodoListScreen;
+export default QuestionToSlideScreen;
 

--- a/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
+++ b/edweiss-app/app/(app)/lectures/remotecontrol/questionToSlide.tsx
@@ -55,11 +55,7 @@ const QuestionToSlideScreen: ApplicationRoute = () => {
     const [selLikes, setSelLikes] = useState(0);
     const [selID, setSelID] = useState("");
     const [broadcasted, setBroadcasted] = useState(""); // Store the currently broadcasted lecture 
-    const theme = useTheme()
-    const broadcastedColorBord = (theme === "light") ? 'rgba(4, 165, 229, 0.3)' : 'rgba(166, 227, 161, 0.6)';
-    const broadcastedColorBack = (theme === "light") ? 'rgba(4, 165, 229, 0.08)' : 'rgba(166, 227, 161, 0.15)';
-    const unbroadcastedColorBord = (theme === "light") ? Colors.light.surface2 : Colors.dark.surface2;
-    const unbroadcastedColorBack = (theme === "light") ? Colors.light.crust : Colors.dark.crust;
+
 
 
     // Dynamic Document
@@ -68,7 +64,7 @@ const QuestionToSlideScreen: ApplicationRoute = () => {
 
     // Wait for lectureDoc to be available
     if (!lectureDoc) return <TActivityIndicator size={40} testID='quest-slide-activity-indicator' />;
-    questionsDoc?.sort((a, b) => b.data.likes - a.data.likes) || []
+    questionsDoc?.sort((a, b) => b.data.likes - a.data.likes);
     const questionDocPending = questionsDoc?.filter(question => !question.data.answered) || [];
     const currentLecture = lectureDoc.data;
 
@@ -78,47 +74,7 @@ const QuestionToSlideScreen: ApplicationRoute = () => {
 
 
 
-    // Handle sigle question
-    const QuestionDisplay: React.FC<{
-        question: Document<Question>;
-        index: number;
-    }> = ({ question, index }) => {
-        const { text, anonym, userID, likes, username } = question.data;
-        const id = question.id;
 
-        return (
-            <TView key={index}
-                style={{
-                    backgroundColor: (broadcasted === id) ? broadcastedColorBack : unbroadcastedColorBack,
-                    borderColor: (broadcasted === id) ? broadcastedColorBord : unbroadcastedColorBord
-                }}
-                b={'xl'}
-                radius={'lg'}
-                flex={1}
-                flexDirection='column'
-                ml='sm' mr='sm'
-                mb='md'
-            >
-                <TTouchableOpacity onPress={() => { setSelID(id); setSelQuestion(text); setSelLikes(likes); setSelUsername(username); Vibration.vibrate(100); modalRefQuestionBroadcast.current?.present() }}>
-                    <TView flexDirection='row' justifyContent='space-between' ml='md' mb='xs'>
-                        {/* Person status */}
-                        <TText size={'sm'} pl={2} pt={'sm'} color='text'>{anonym ? "Anonym" : username}</TText>
-
-                        {/* Likes Status */}
-                        <TView flexDirection='row' mt='sm' mr='sm'>
-                            <TText>{likes}</TText>
-                            <Icon size={'md'} name={likes === 0 ? 'heart-outline' : 'heart'} color='red' ml='xs' mt='xs'></Icon>
-                        </TView>
-                    </TView>
-
-                    {/* Question Content */}
-                    <TView pr={'sm'} pl={'md'} pb={'sm'} flexDirection='row' justifyContent='space-between' alignItems='flex-start'>
-                        <TText ml={10} color='overlay2'>{text}</TText>
-                    </TView>
-                </TTouchableOpacity>
-            </TView >
-        );
-    }
 
     return (
         <>
@@ -130,7 +86,7 @@ const QuestionToSlideScreen: ApplicationRoute = () => {
             {questionDocPending && questionDocPending.length > 0 ? (
                 <TScrollView>
                     <For each={questionDocPending}>
-                        {(question, index) => <QuestionDisplay question={question} index={index} />}
+                        {(question, index) => <QuestionDisplay question={question} index={index} broadcasted={broadcasted} setSelID={setSelID} setSelQuestion={setSelQuestion} setSelLikes={setSelLikes} setSelUsername={setSelUsername} modalRefQuestionBroadcast={modalRefQuestionBroadcast} />}
                     </For>
                 </TScrollView>
             ) : (
@@ -152,3 +108,60 @@ const QuestionToSlideScreen: ApplicationRoute = () => {
 
 export default QuestionToSlideScreen;
 
+
+
+// ---------------------------------------------
+// ----   Utils Question Display Component  ----
+// ---------------------------------------------
+
+const QuestionDisplay: React.FC<{
+    question: Document<Question>;
+    index: number;
+    broadcasted: string;
+    setSelID: (id: string) => void;
+    setSelQuestion: (text: string) => void;
+    setSelLikes: (likes: number) => void;
+    setSelUsername: (username: string) => void;
+    modalRefQuestionBroadcast: React.RefObject<BottomSheetModal>;
+}> = ({ question, index, broadcasted, setSelID, setSelQuestion, setSelLikes, setSelUsername, modalRefQuestionBroadcast }) => {
+    const { text, anonym, likes, username } = question.data;
+    const id = question.id;
+    const theme = useTheme()
+    const broadcastedColorBord = (theme === "light") ? 'rgba(4, 165, 229, 0.3)' : 'rgba(166, 227, 161, 0.6)';
+    const broadcastedColorBack = (theme === "light") ? 'rgba(4, 165, 229, 0.08)' : 'rgba(166, 227, 161, 0.15)';
+    const unbroadcastedColorBord = (theme === "light") ? Colors.light.surface2 : Colors.dark.surface2;
+    const unbroadcastedColorBack = (theme === "light") ? Colors.light.crust : Colors.dark.crust;
+
+    return (
+        <TView key={index}
+            style={{
+                backgroundColor: (broadcasted === id) ? broadcastedColorBack : unbroadcastedColorBack,
+                borderColor: (broadcasted === id) ? broadcastedColorBord : unbroadcastedColorBord
+            }}
+            b={'xl'}
+            radius={'lg'}
+            flex={1}
+            flexDirection='column'
+            ml='sm' mr='sm'
+            mb='md'
+        >
+            <TTouchableOpacity onPress={() => { setSelID(id); setSelQuestion(text); setSelLikes(likes); setSelUsername(username); Vibration.vibrate(100); modalRefQuestionBroadcast.current?.present() }}>
+                <TView flexDirection='row' justifyContent='space-between' ml='md' mb='xs'>
+                    {/* Person status */}
+                    <TText size={'sm'} pl={2} pt={'sm'} color='text'>{anonym ? "Anonym" : username}</TText>
+
+                    {/* Likes Status */}
+                    <TView flexDirection='row' mt='sm' mr='sm'>
+                        <TText>{likes}</TText>
+                        <Icon size={'md'} name={likes === 0 ? 'heart-outline' : 'heart'} color='red' ml='xs' mt='xs'></Icon>
+                    </TView>
+                </TView>
+
+                {/* Question Content */}
+                <TView pr={'sm'} pl={'md'} pb={'sm'} flexDirection='row' justifyContent='space-between' alignItems='flex-start'>
+                    <TText ml={10} color='overlay2'>{text}</TText>
+                </TView>
+            </TTouchableOpacity>
+        </TView >
+    );
+}

--- a/edweiss-app/app/(app)/lectures/slides/index.tsx
+++ b/edweiss-app/app/(app)/lectures/slides/index.tsx
@@ -291,7 +291,6 @@ const LectureViewer: React.FC<{
             horizontal
             style={{
                 flex: 1,
-                backgroundColor: colorScheme == "dark" ? "#181825" : "#e6e9ef",
                 width: Dimensions.get('window').width * widthPorp,
                 height: Dimensions.get('window').height * heightProp,
             }}

--- a/edweiss-app/app/(app)/lectures/slides/index.tsx
+++ b/edweiss-app/app/(app)/lectures/slides/index.tsx
@@ -107,7 +107,7 @@ const LectureScreen: ApplicationRoute = () => {
 
     if (questionsDoc && currentEvent && currentEvent.type === "question") {
         const targetID = currentEvent.id;
-        currentQuestion = questionsDoc!.find(question => question.id === targetID)?.data || undefined;
+        currentQuestion = questionsDoc.find(question => question.id === targetID)?.data || undefined;
     }
 
     // Function to go to the next page
@@ -129,53 +129,7 @@ const LectureScreen: ApplicationRoute = () => {
         }
     };
 
-    const LectureViewer = (uri: string, widthPorp: number, heightProp: number) => {
 
-        return (currentEvent && currentEvent.type === "invalid") ? (
-            <Pdf
-                trustAllCerts={false}
-                source={{ uri }}
-                renderActivityIndicator={() => <ActivityIndicator size="large" />}
-                enablePaging
-                onLoadComplete={(totalPages) => setNumPages(totalPages)}
-                onPageChanged={(currentPage) => setCurrentPage(currentPage)}
-                onError={(error) => console.log(error)}
-                page={page}
-                horizontal
-                style={{
-                    flex: 1,
-                    width: Dimensions.get('window').width * widthPorp,
-                    height: Dimensions.get('window').height * heightProp,
-                }}
-            />
-        ) : (
-
-            currentQuestion && <>
-                <TView justifyContent='center' alignItems='center' mt='lg' mb={isLandscape ? 'sm' : 'xs'}>
-                    <TText bold size='lg' mb='sm'>{t('showtime:question_broadcast_ans_title')}</TText>
-                </TView>
-
-
-                <TText ml={'md'} color='overlay2' mt='xs' mb={isLandscape ? 'lg' : 'xs'} bold>{currentQuestion.username === "" ? t('showtime:anony_ask_question') : currentQuestion.username} {t('showtime:question_broadcast_modal_says')}</TText>
-
-
-                <TView justifyContent='center' alignItems='center' m={'md'} mb={isLandscape ? 'lg' : 'xs'}>
-                    <TText size={'lg'} color='overlay2' align='center'>« {currentQuestion.text} »</TText>
-                </TView>
-
-
-                <TView flexDirection='column' alignItems='flex-end' mt={isLandscape ? 'md' : 'xs'}>
-                    {currentQuestion.likes > 0 && (
-                        <>
-                            <TText ml={'md'} color='overlay2' mr='lg'>{currentQuestion.likes} {t('showtime:other_student')}</TText>
-                            <TText ml={'md'} color='overlay2' mr='lg'>{t('showtime:are_interrested')}</TText>
-                        </>
-                    )}
-                </TView>
-
-            </>
-        );
-    }
 
 
     const ControlButtons = () => (
@@ -258,7 +212,7 @@ const LectureScreen: ApplicationRoute = () => {
             {isFullscreen ?
 
                 <TView mr={'lg'} flexDirection='column' style={{ width: '100%', height: '100%', position: 'relative' }} >
-                    {LectureViewer(uri, 1, 1)}
+                    {LectureViewer({ uri, widthPorp: 1, heightProp: 1, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape })}
                     {ControlButtons()}
                 </TView>
 
@@ -266,7 +220,7 @@ const LectureScreen: ApplicationRoute = () => {
                 : isLandscape ?
                     <TView flexDirection={'row'} flex={1} style={{ width: '100%' }}>
                         <TView flexDirection='column' style={{ width: '60%', height: '100%', position: 'relative' }} >
-                            {LectureViewer(uri, 0.6, 1)}
+                            {LectureViewer({ uri, widthPorp: 0.6, heightProp: 1, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape })}
                             {ControlButtons()}
                         </TView>
                         {ContentView('40%', '100%')}
@@ -276,7 +230,7 @@ const LectureScreen: ApplicationRoute = () => {
                     :
                     <TView flexDirection={'column'} flex={1} style={{ width: '100%' }}>
                         <TView flexDirection='column' style={{ width: '100%', height: '40%', position: 'relative' }} >
-                            {LectureViewer(uri, 1, 0.6)}
+                            {LectureViewer({ uri, widthPorp: 1, heightProp: 0.6, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape })}
                             {ControlButtons()}
                         </TView>
                         {ContentView('100%', '60%')}
@@ -291,3 +245,68 @@ const LectureScreen: ApplicationRoute = () => {
 };
 
 export default LectureScreen;
+
+
+
+
+// ---------------------------------------------
+// -----   Utils Lecture Viewer Component  -----
+// ---------------------------------------------
+
+const LectureViewer: React.FC<{
+    uri: string;
+    widthPorp: number;
+    heightProp: number;
+    currentEvent: LectureDisplay.LectureEventBase | undefined;
+    currentQuestion: Question | undefined;
+    setNumPages: (numPages: number) => void;
+    setCurrentPage: (currentPage: number) => void;
+    page: number;
+    isLandscape: boolean;
+}> = ({ uri, widthPorp, heightProp, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape }) => {
+
+    return (currentEvent && currentEvent.type === "invalid") ? (
+        <Pdf
+            trustAllCerts={false}
+            source={{ uri }}
+            renderActivityIndicator={() => <ActivityIndicator size="large" />}
+            enablePaging
+            onLoadComplete={(totalPages) => setNumPages(totalPages)}
+            onPageChanged={(currentPage) => setCurrentPage(currentPage)}
+            onError={(error) => console.log(error)}
+            page={page}
+            horizontal
+            style={{
+                flex: 1,
+                width: Dimensions.get('window').width * widthPorp,
+                height: Dimensions.get('window').height * heightProp,
+            }}
+        />
+    ) : (
+
+        currentQuestion && <>
+            <TView justifyContent='center' alignItems='center' mt='lg' mb={isLandscape ? 'sm' : 'xs'}>
+                <TText bold size='lg' mb='sm'>{t('showtime:question_broadcast_ans_title')}</TText>
+            </TView>
+
+
+            <TText ml={'md'} color='overlay2' mt='xs' mb={isLandscape ? 'lg' : 'xs'} bold>{currentQuestion.username === "" ? t('showtime:anony_ask_question') : currentQuestion.username} {t('showtime:question_broadcast_modal_says')}</TText>
+
+
+            <TView justifyContent='center' alignItems='center' m={'md'} mb={isLandscape ? 'lg' : 'xs'}>
+                <TText size={'lg'} color='overlay2' align='center'>« {currentQuestion.text} »</TText>
+            </TView>
+
+
+            <TView flexDirection='column' alignItems='flex-end' mt={isLandscape ? 'md' : 'xs'}>
+                {currentQuestion.likes > 0 && (
+                    <>
+                        <TText ml={'md'} color='overlay2' mr='lg'>{currentQuestion.likes} {t('showtime:other_student')}</TText>
+                        <TText ml={'md'} color='overlay2' mr='lg'>{t('showtime:are_interrested')}</TText>
+                    </>
+                )}
+            </TView>
+
+        </>
+    );
+}

--- a/edweiss-app/app/(app)/lectures/slides/index.tsx
+++ b/edweiss-app/app/(app)/lectures/slides/index.tsx
@@ -98,9 +98,17 @@ const LectureScreen: ApplicationRoute = () => {
             ScreenOrientation.removeOrientationChangeListener(screenOrientationListener);
         };
     }, []);
+    let currentQuestion: Question | undefined = undefined;
+    let currentEvent: LectureDisplay.LectureEventBase | undefined;
 
     if (!lectureDoc) return <TActivityIndicator size={40} testID='activity-indicator' />;
     const currentLecture = lectureDoc.data;
+    currentEvent = currentLecture.event;
+
+    if (questionsDoc && currentEvent && currentEvent.type === "question") {
+        const targetID = currentEvent.id;
+        currentQuestion = questionsDoc!.find(question => question.id === targetID)?.data || undefined;
+    }
 
     // Function to go to the next page
     function pageForward() {
@@ -121,24 +129,54 @@ const LectureScreen: ApplicationRoute = () => {
         }
     };
 
-    const PDFViewer = (uri: string, widthPorp: number, heightProp: number) => (
-        <Pdf
-            trustAllCerts={false}
-            source={{ uri }}
-            renderActivityIndicator={() => <ActivityIndicator size="large" />}
-            enablePaging
-            onLoadComplete={(totalPages) => setNumPages(totalPages)}
-            onPageChanged={(currentPage) => setCurrentPage(currentPage)}
-            onError={(error) => console.log(error)}
-            page={page}
-            horizontal
-            style={{
-                flex: 1,
-                width: Dimensions.get('window').width * widthPorp,
-                height: Dimensions.get('window').height * heightProp,
-            }}
-        />
-    );
+    const LectureViewer = (uri: string, widthPorp: number, heightProp: number) => {
+
+        return (currentEvent && currentEvent.type === "invalid") ? (
+            <Pdf
+                trustAllCerts={false}
+                source={{ uri }}
+                renderActivityIndicator={() => <ActivityIndicator size="large" />}
+                enablePaging
+                onLoadComplete={(totalPages) => setNumPages(totalPages)}
+                onPageChanged={(currentPage) => setCurrentPage(currentPage)}
+                onError={(error) => console.log(error)}
+                page={page}
+                horizontal
+                style={{
+                    flex: 1,
+                    width: Dimensions.get('window').width * widthPorp,
+                    height: Dimensions.get('window').height * heightProp,
+                }}
+            />
+        ) : (
+
+            currentQuestion && <>
+                <TView justifyContent='center' alignItems='center' mt='lg' mb={isLandscape ? 'sm' : 'xs'}>
+                    <TText bold size='lg' mb='sm'>{t('showtime:question_broadcast_ans_title')}</TText>
+                </TView>
+
+
+                <TText ml={'md'} color='overlay2' mt='xs' mb={isLandscape ? 'lg' : 'xs'} bold>{currentQuestion.username === "" ? t('showtime:anony_ask_question') : currentQuestion.username} {t('showtime:question_broadcast_modal_says')}</TText>
+
+
+                <TView justifyContent='center' alignItems='center' m={'md'} mb={isLandscape ? 'lg' : 'xs'}>
+                    <TText size={'lg'} color='overlay2' align='center'>« {currentQuestion.text} »</TText>
+                </TView>
+
+
+                <TView flexDirection='column' alignItems='flex-end' mt={isLandscape ? 'md' : 'xs'}>
+                    {currentQuestion.likes > 0 && (
+                        <>
+                            <TText ml={'md'} color='overlay2' mr='lg'>{currentQuestion.likes} {t('showtime:other_student')}</TText>
+                            <TText ml={'md'} color='overlay2' mr='lg'>{t('showtime:are_interrested')}</TText>
+                        </>
+                    )}
+                </TView>
+
+            </>
+        );
+    }
+
 
     const ControlButtons = () => (
         <TView alignItems='center' flexDirection='row' justifyContent='space-between' style={{ position: 'absolute', bottom: 0, left: 0, width: '100%' }} backgroundColor='overlay0'>
@@ -220,7 +258,7 @@ const LectureScreen: ApplicationRoute = () => {
             {isFullscreen ?
 
                 <TView mr={'lg'} flexDirection='column' style={{ width: '100%', height: '100%', position: 'relative' }} >
-                    {PDFViewer(uri, 1, 1)}
+                    {LectureViewer(uri, 1, 1)}
                     {ControlButtons()}
                 </TView>
 
@@ -228,7 +266,7 @@ const LectureScreen: ApplicationRoute = () => {
                 : isLandscape ?
                     <TView flexDirection={'row'} flex={1} style={{ width: '100%' }}>
                         <TView flexDirection='column' style={{ width: '60%', height: '100%', position: 'relative' }} >
-                            {PDFViewer(uri, 0.6, 1)}
+                            {LectureViewer(uri, 0.6, 1)}
                             {ControlButtons()}
                         </TView>
                         {ContentView('40%', '100%')}
@@ -238,7 +276,7 @@ const LectureScreen: ApplicationRoute = () => {
                     :
                     <TView flexDirection={'column'} flex={1} style={{ width: '100%' }}>
                         <TView flexDirection='column' style={{ width: '100%', height: '40%', position: 'relative' }} >
-                            {PDFViewer(uri, 1, 0.6)}
+                            {LectureViewer(uri, 1, 0.6)}
                             {ControlButtons()}
                         </TView>
                         {ContentView('100%', '60%')}

--- a/edweiss-app/app/(app)/quiz/createLectureQuizPage.tsx
+++ b/edweiss-app/app/(app)/quiz/createLectureQuizPage.tsx
@@ -1,5 +1,6 @@
 import RouteHeader from '@/components/core/header/RouteHeader';
 import { ApplicationRoute } from '@/constants/Component';
+import React from 'react';
 
 import TScrollView from '@/components/core/containers/TScrollView';
 import TView from '@/components/core/containers/TView';
@@ -71,6 +72,7 @@ const CreateLectureQuizPage: ApplicationRoute = () => {
 		}
 
 		const newLectureQuiz: LectureDisplay.QuizLectureEvent = {
+			id: "",
 			done: false,
 			pageNumber: 1,
 			quizModel: newQuiz,

--- a/edweiss-app/app/(app)/quiz/lectureQuizStudentView.tsx
+++ b/edweiss-app/app/(app)/quiz/lectureQuizStudentView.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 export const LectureQuizStudentViewSignature: ApplicationRouteSignature<{
 	courseId: string, lectureId: string, lectureEventId: string
-	prefetchedQuiz: Document<LectureDisplay.LectureEvent> | undefined
+	prefetchedQuiz: Document<LectureDisplay.QuizLectureEvent> | undefined
 }> = {
 	path: "/(app)/quiz/lectureQuizStudentView" as any
 }
@@ -31,7 +31,7 @@ const LectureQuizStudentView: ApplicationRoute = () => {
 	const pathToLectureEvents = "courses/" + courseId + "/lectures/" + lectureId + "/lectureEvents"
 	const pathToAttempts = pathToLectureEvents + "/" + lectureEventId + "/attempts";
 	const { uid } = useAuth();
-	const [quizEvent] = usePrefetchedDynamicDoc(CollectionOf<LectureDisplay.LectureEvent>(pathToLectureEvents), lectureEventId, prefetchedQuiz);
+	const [quizEvent] = usePrefetchedDynamicDoc(CollectionOf<LectureDisplay.QuizLectureEvent>(pathToLectureEvents), lectureEventId, prefetchedQuiz);
 	const previousAttempt = useDoc(CollectionOf<LectureQuizzesAttempts.LectureQuizAttempt>(pathToAttempts), uid);
 	const [studentAnswer, setStudentAnswer] = useState<QuizzesAttempts.Answer | undefined>(undefined);
 	const quiz = quizEvent?.data.quizModel

--- a/edweiss-app/app/(app)/quiz/temporaryQuizProfView.tsx
+++ b/edweiss-app/app/(app)/quiz/temporaryQuizProfView.tsx
@@ -1,5 +1,6 @@
 import RouteHeader from '@/components/core/header/RouteHeader';
 import ReactComponent, { ApplicationRoute } from '@/constants/Component';
+import React from 'react';
 
 import For from '@/components/core/For';
 import TActivityIndicator from '@/components/core/TActivityIndicator';
@@ -16,7 +17,7 @@ import { useEffect } from 'react';
 
 export const TemporaryQuizProfViewSignature: ApplicationRouteSignature<{
 	courseId: string, lectureId: string, lectureEventId: string
-	prefetchedQuizEvent: Document<LectureDisplay.LectureEvent> | undefined
+	prefetchedQuizEvent: Document<LectureDisplay.QuizLectureEvent> | undefined
 }> = {
 	path: "/(app)/quiz/temporaryQuizProfView" as any
 }
@@ -26,7 +27,7 @@ const TemporaryQuizProfView: ApplicationRoute = () => {
 	const pathToEvents = "courses/" + courseId + "/lectures/" + lectureId + "/lectureEvents"
 	const pathToAttempts = pathToEvents + "/" + lectureEventId + "/attempts"
 
-	const [quizEvent, loading] = usePrefetchedDynamicDoc(CollectionOf<LectureDisplay.LectureEvent>(pathToEvents), lectureEventId as string, prefetchedQuizEvent);
+	const [quizEvent, loading] = usePrefetchedDynamicDoc(CollectionOf<LectureDisplay.QuizLectureEvent>(pathToEvents), lectureEventId as string, prefetchedQuizEvent);
 	const studentAttempts = useDocs(CollectionOf<LectureQuizzesAttempts.LectureQuizAttempt>(pathToAttempts));
 
 	const quiz = quizEvent?.data.quizModel

--- a/edweiss-app/components/lectures/remotecontrol/abstractRmtCtl.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/abstractRmtCtl.tsx
@@ -212,11 +212,17 @@ export const AbstractRmtCrl: React.FC<AbstractRmtCrlProps & LightDarkProps> = ({
                         <TTouchableOpacity
                             backgroundColor='crust'
                             borderColor='text' p={10} b={1} mr={'md'} radius={1000}
-                            onPress={() => Toast.show({
-                                type: 'success',
-                                text1: 'The Audiance  Questions',
-                                text2: 'Implementation comes soon'
-                            })}
+                            onPress={() =>
+                                router.push({
+                                    pathname: '/(app)/lectures/remotecontrol/questionToSlide' as any,
+                                    // params: {
+                                    //     courseNameString,
+                                    //     lectureIdString,
+                                    //     currentPageString: curPageProvided.toString(),
+                                    //     totalPageString: totPageProvided.toString(),
+                                    // },
+                                })
+                            }
                             testID='strc-chat-button'>
                             <Icon size={40} name='chatbubbles-outline' color='text'></Icon>
                         </TTouchableOpacity>

--- a/edweiss-app/components/lectures/remotecontrol/abstractRmtCtl.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/abstractRmtCtl.tsx
@@ -215,12 +215,12 @@ export const AbstractRmtCrl: React.FC<AbstractRmtCrlProps & LightDarkProps> = ({
                             onPress={() =>
                                 router.push({
                                     pathname: '/(app)/lectures/remotecontrol/questionToSlide' as any,
-                                    // params: {
-                                    //     courseNameString,
-                                    //     lectureIdString,
-                                    //     currentPageString: curPageProvided.toString(),
-                                    //     totalPageString: totPageProvided.toString(),
-                                    // },
+                                    params: {
+                                        courseNameString,
+                                        lectureIdString,
+                                        currentPageString: curPageProvided.toString(),
+                                        totalPageString: totPageProvided.toString(),
+                                    },
                                 })
                             }
                             testID='strc-chat-button'>

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -452,17 +452,37 @@ export const QuestionBroadcastModal: ReactComponent<{
         if (broadcasted === id) {
 
             // Question has been answered 
-            const res = await callFunction(LectureDisplay.Functions.markQuestionAsAnswered, {
-                courseId: courseId,
-                lectureId: lectureId,
-                id: id,
-                answered: true,
-            });
+            try {
+                callFunction(LectureDisplay.Functions.markQuestionAsAnswered, {
+                    courseId: courseId,
+                    lectureId: lectureId,
+                    id: id,
+                    answered: true,
+                });
+                callFunction(LectureDisplay.Functions.clearQuestionEvent, {
+                    courseId: courseId,
+                    lectureId: lectureId,
+                    id: id,
+                });
+                console.log("Question Cleared")
+            } catch (error) { console.error("Error adding audio transcript:", error); }
+
+
             setBroadcasted("");
 
         } else {
 
             // Broadcast the question to the audience
+            try {
+                callFunction(LectureDisplay.Functions.broadcastQuestion, {
+                    courseId: courseId,
+                    lectureId: lectureId,
+                    id: id,
+                });
+                console.log("Question Broadcasted")
+            } catch (error) { console.error("Error adding audio transcript:", error); }
+
+
             setBroadcasted(id);
             console.log("Broadcast the question to the audience");
         };

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -461,10 +461,22 @@ export const QuestionBroadcastModal: ReactComponent<{
                     <TText bold size='lg' mb='sm'>{t('showtime:question_broadcast_modal_title')}</TText>
                 </TView>
 
-                <TView justifyContent='center' alignItems='center'>
-                    <TText ml={10} color='overlay2'>{question}</TText>
-                    <TText ml={10} color='overlay2'>{username}</TText>
-                    <TText ml={10} color='overlay2'>{likes}</TText>
+
+                <TText ml={'md'} color='overlay2' bold>{username === "" ? t('showtime:anony_ask_question') : username} {t('showtime:question_broadcast_modal_says')}</TText>
+
+
+                <TView justifyContent='center' alignItems='center' m={'md'}>
+                    <TText ml={10} size={'lg'} color='overlay2'>« {question} »</TText>
+                </TView>
+
+
+                <TView flexDirection='column' alignItems='flex-end' mt='md'>
+                    {likes > 0 && (
+                        <>
+                            <TText ml={10} color='overlay2' mr='lg'>{likes} other student also want</TText>
+                            <TText ml={10} color='overlay2' mr='lg'>to know about this</TText>
+                        </>
+                    )}
                 </TView>
 
                 <FancyButton backgroundColor='subtext0' m='md' outlined onPress={handleQuestionBroadcast} testID='brod-quest-ans-button'>

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -466,7 +466,6 @@ export const QuestionBroadcastModal: ReactComponent<{
                 });
             } catch (error) { console.error("Error updating the question event:", error); }
 
-
             setBroadcasted("");
 
         } else {
@@ -478,13 +477,9 @@ export const QuestionBroadcastModal: ReactComponent<{
                     lectureId: lectureId,
                     id: id,
                 });
-                console.log("Question Broadcasted")
             } catch (error) { console.error("Error updating the question event:", error); }
 
-
-
             setBroadcasted(id);
-            console.log("Broadcast the question to the audience");
         };
     }
 

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -464,8 +464,7 @@ export const QuestionBroadcastModal: ReactComponent<{
                     lectureId: lectureId,
                     id: id,
                 });
-                console.log("Question Cleared")
-            } catch (error) { console.error("Error adding audio transcript:", error); }
+            } catch (error) { console.error("Error updating the question event:", error); }
 
 
             setBroadcasted("");
@@ -513,11 +512,11 @@ export const QuestionBroadcastModal: ReactComponent<{
                     )}
                 </TView>
 
-                <FancyButton backgroundColor='subtext0' m='md' outlined onPress={handleQuestionBroadcast} testID='brod-quest-ans-button'>
+                <FancyButton m='md' mb='sm' icon={broadcasted === id ? 'cloud-done-outline' : 'paper-plane-outline'} onPress={handleQuestionBroadcast} testID='brod-quest-ans-button'>
                     {broadcasted === id ? t('showtime:question_answered') : t('showtime:broadcast_question')}
                 </FancyButton>
 
-                <FancyButton backgroundColor='subtext0' m='md' onPress={onClose} outlined testID='brod-quest-close-button'>
+                <FancyButton backgroundColor='subtext0' m='md' mt='sm' onPress={onClose} outlined testID='brod-quest-close-button'>
                     {t('showtime:close_btn')}
                 </FancyButton>
             </>

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -453,13 +453,13 @@ export const QuestionBroadcastModal: ReactComponent<{
 
             // Question has been answered 
             try {
-                callFunction(LectureDisplay.Functions.markQuestionAsAnswered, {
+                await callFunction(LectureDisplay.Functions.markQuestionAsAnswered, {
                     courseId: courseId,
                     lectureId: lectureId,
                     id: id,
                     answered: true,
                 });
-                callFunction(LectureDisplay.Functions.clearQuestionEvent, {
+                await callFunction(LectureDisplay.Functions.clearQuestionEvent, {
                     courseId: courseId,
                     lectureId: lectureId,
                     id: id,
@@ -472,7 +472,7 @@ export const QuestionBroadcastModal: ReactComponent<{
 
             // Broadcast the question to the audience
             try {
-                callFunction(LectureDisplay.Functions.broadcastQuestion, {
+                await callFunction(LectureDisplay.Functions.broadcastQuestion, {
                     courseId: courseId,
                     lectureId: lectureId,
                     id: id,

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -425,3 +425,56 @@ export const TimerSettingModal: ReactComponent<{
         </ModalContainer >
     );
 };
+
+
+
+
+// ------------------------------------------------------------
+// -------------      Question Broadcast Modal    -------------
+// ------------------------------------------------------------
+
+export const QuestionBroadcastModal: ReactComponent<{
+    modalRef: React.RefObject<BottomSheetModalMethods>;
+    id: string;
+    question: string;
+    username: string;
+    likes: number;
+    broadcasted: string,
+    setBroadcasted: React.Dispatch<React.SetStateAction<string>>;
+    onClose: () => void;
+}> = ({ modalRef, id, question, username, likes, broadcasted, setBroadcasted, onClose }) => {
+
+    const handleQuestionBroadcast = () => {
+        if (broadcasted === id) {
+            setBroadcasted("");
+        } else {
+            setBroadcasted(id);
+        }
+
+        onClose();
+    };
+
+    return (
+        <ModalContainer modalRef={modalRef}>
+            <>
+                <TView justifyContent='center' alignItems='center' mb='sm'>
+                    <TText bold size='lg' mb='sm'>{t('showtime:question_broadcast_modal_title')}</TText>
+                </TView>
+
+                <TView justifyContent='center' alignItems='center'>
+                    <TText ml={10} color='overlay2'>{question}</TText>
+                    <TText ml={10} color='overlay2'>{username}</TText>
+                    <TText ml={10} color='overlay2'>{likes}</TText>
+                </TView>
+
+                <FancyButton backgroundColor='subtext0' m='md' outlined onPress={handleQuestionBroadcast} testID='brod-quest-ans-button'>
+                    {t('showtime:broadcast_question')}
+                </FancyButton>
+
+                <FancyButton backgroundColor='subtext0' m='md' onPress={onClose} outlined testID='brod-quest-close-button'>
+                    {t('showtime:close_btn')}
+                </FancyButton>
+            </>
+        </ModalContainer>
+    );
+};

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -479,7 +479,8 @@ export const QuestionBroadcastModal: ReactComponent<{
                     id: id,
                 });
                 console.log("Question Broadcasted")
-            } catch (error) { console.error("Error adding audio transcript:", error); }
+            } catch (error) { console.error("Error updating the question event:", error); }
+
 
 
             setBroadcasted(id);

--- a/edweiss-app/components/lectures/remotecontrol/modal.tsx
+++ b/edweiss-app/components/lectures/remotecontrol/modal.tsx
@@ -15,6 +15,7 @@ import Icon from '@/components/core/Icon';
 import ModalContainer from '@/components/core/modal/ModalContainer';
 import TText from '@/components/core/TText';
 import FancyButton from '@/components/input/FancyButton';
+import { callFunction } from '@/config/firebase';
 import { LightDarkProps } from '@/constants/Colors';
 import ReactComponent from '@/constants/Component';
 import { TIME_CONSTANTS } from '@/constants/Time';
@@ -436,23 +437,36 @@ export const TimerSettingModal: ReactComponent<{
 export const QuestionBroadcastModal: ReactComponent<{
     modalRef: React.RefObject<BottomSheetModalMethods>;
     id: string;
+    courseId: string,
+    lectureId: string,
     question: string;
     username: string;
     likes: number;
     broadcasted: string,
     setBroadcasted: React.Dispatch<React.SetStateAction<string>>;
     onClose: () => void;
-}> = ({ modalRef, id, question, username, likes, broadcasted, setBroadcasted, onClose }) => {
+}> = ({ modalRef, id, courseId, lectureId, question, username, likes, broadcasted, setBroadcasted, onClose }) => {
 
-    const handleQuestionBroadcast = () => {
-        if (broadcasted === id) {
-            setBroadcasted("");
-        } else {
-            setBroadcasted(id);
-        }
-
+    async function handleQuestionBroadcast() {
         onClose();
-    };
+        if (broadcasted === id) {
+
+            // Question has been answered 
+            const res = await callFunction(LectureDisplay.Functions.markQuestionAsAnswered, {
+                courseId: courseId,
+                lectureId: lectureId,
+                id: id,
+                answered: true,
+            });
+            setBroadcasted("");
+
+        } else {
+
+            // Broadcast the question to the audience
+            setBroadcasted(id);
+            console.log("Broadcast the question to the audience");
+        };
+    }
 
     return (
         <ModalContainer modalRef={modalRef}>
@@ -466,21 +480,21 @@ export const QuestionBroadcastModal: ReactComponent<{
 
 
                 <TView justifyContent='center' alignItems='center' m={'md'}>
-                    <TText ml={10} size={'lg'} color='overlay2'>« {question} »</TText>
+                    <TText size={'lg'} color='overlay2' align='center'>« {question} »</TText>
                 </TView>
 
 
                 <TView flexDirection='column' alignItems='flex-end' mt='md'>
                     {likes > 0 && (
                         <>
-                            <TText ml={10} color='overlay2' mr='lg'>{likes} other student also want</TText>
-                            <TText ml={10} color='overlay2' mr='lg'>to know about this</TText>
+                            <TText ml={'md'} color='overlay2' mr='lg'>{likes} {t('showtime:other_student')}</TText>
+                            <TText ml={'md'} color='overlay2' mr='lg'>{t('showtime:are_interrested')}</TText>
                         </>
                     )}
                 </TView>
 
                 <FancyButton backgroundColor='subtext0' m='md' outlined onPress={handleQuestionBroadcast} testID='brod-quest-ans-button'>
-                    {t('showtime:broadcast_question')}
+                    {broadcasted === id ? t('showtime:question_answered') : t('showtime:broadcast_question')}
                 </FancyButton>
 
                 <FancyButton backgroundColor='subtext0' m='md' onPress={onClose} outlined testID='brod-quest-close-button'>

--- a/edweiss-app/locales/en/showtime.json
+++ b/edweiss-app/locales/en/showtime.json
@@ -27,9 +27,11 @@
     "lecturer_transcript_deftxt" : "Lecturer’s transcript... currently in invisible ink!",
     "question_broadcast_modal_title": "Answer Question",
     "broadcast_question": "Broadcast Question",
+    "question_answered": "Question Answered",
     "question_broadcast_modal_says": "asks :",
     "anony_ask_question": "An anomym student",
-    "are_interested": "other students also what to know about this",
+    "other_student": "other student also want",
+    "are_interrested":"to know about this.",
 
     "dummy_question_0" : "Why do we say ‘sleep like a baby’ when babies wake up every two hours?",
     "dummy_question_1" : "Why do we call it ‘quick sand’ if it’s so slow?",

--- a/edweiss-app/locales/en/showtime.json
+++ b/edweiss-app/locales/en/showtime.json
@@ -19,6 +19,10 @@
     "rmt_ctl_timer": "Timer",
     "rmt_ctl_recall": "Recall",
     "close_btn": "Close",
+    "question_slide_title": "Audience Questions",
+    "empty_question": "No Question from the Audience",
+    "empty_question_funny_1": "Your explanation must have been clear",
+    "empty_question_funny_2": " ... or the students are totally lost",
 
     "lecturer_transcript_deftxt" : "Lecturer’s transcript... currently in invisible ink!",
     

--- a/edweiss-app/locales/en/showtime.json
+++ b/edweiss-app/locales/en/showtime.json
@@ -25,7 +25,9 @@
     "empty_question_funny_2": " ... or the students are totally lost",
 
     "lecturer_transcript_deftxt" : "Lecturer’s transcript... currently in invisible ink!",
-    
+    "question_broadcast_modal_title": "Answer Question",
+    "broadcast_question": "Broadcast Question",
+
     "dummy_question_0" : "Why do we say ‘sleep like a baby’ when babies wake up every two hours?",
     "dummy_question_1" : "Why do we call it ‘quick sand’ if it’s so slow?",
     "dummy_question_2" : "If a tomato is a fruit, does that make ketchup a smoothie?",

--- a/edweiss-app/locales/en/showtime.json
+++ b/edweiss-app/locales/en/showtime.json
@@ -27,6 +27,9 @@
     "lecturer_transcript_deftxt" : "Lecturer’s transcript... currently in invisible ink!",
     "question_broadcast_modal_title": "Answer Question",
     "broadcast_question": "Broadcast Question",
+    "question_broadcast_modal_says": "asks :",
+    "anony_ask_question": "An anomym student",
+    "are_interested": "other students also what to know about this",
 
     "dummy_question_0" : "Why do we say ‘sleep like a baby’ when babies wake up every two hours?",
     "dummy_question_1" : "Why do we call it ‘quick sand’ if it’s so slow?",

--- a/edweiss-app/locales/en/showtime.json
+++ b/edweiss-app/locales/en/showtime.json
@@ -32,6 +32,7 @@
     "anony_ask_question": "An anomym student",
     "other_student": "other student also want",
     "are_interrested":"to know about this.",
+    "question_broadcast_ans_title": "Answering an Audience Question", 
 
     "dummy_question_0" : "Why do we say ‘sleep like a baby’ when babies wake up every two hours?",
     "dummy_question_1" : "Why do we call it ‘quick sand’ if it’s so slow?",

--- a/edweiss-app/model/lectures/lectureDoc.ts
+++ b/edweiss-app/model/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz";
+	export type LectureEvents = "quiz" | "question";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -29,12 +29,16 @@ namespace LectureDisplay {
 	interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
-		pageNumber: number;
+		id: string;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
 		quizModel: Quizzes.Quiz;
+	}
+
+	export interface QuestionLectureEvent extends LectureEventBase {
+		type: "question";
 	}
 
 	export interface Question {
@@ -44,6 +48,7 @@ namespace LectureDisplay {
 		anonym: boolean,
 		likes: number,
 		postedTime: Timestamp,
+		answered: boolean,
 	}
 
 	export interface Lecture {
@@ -51,12 +56,15 @@ namespace LectureDisplay {
 		nbOfPages: number;
 		availableToStudents: boolean;
 		audioTranscript: { [pageNumber: number]: MultiLangTranscript; };
+		event?: LectureEventBase;
 	}
 
 	export const Functions = FunctionFolder("lectures", {
 		addAudioTranscript: FunctionOf<{ courseId: string, lectureId: string, pageNumber: number, transcription: string; }, {}, 'invalid_arg' | 'error_firebase' | 'successfully_added'>("addAudioTranscript"),
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
+		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
 	});
 }
 

--- a/edweiss-app/model/lectures/lectureDoc.ts
+++ b/edweiss-app/model/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz" | "question";
+	export type LectureEvents = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -64,7 +64,8 @@ namespace LectureDisplay {
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
 		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
-		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("broadcastQuestion"),
+		clearQuestionEvent: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("clearQuestionEvent"),
 	});
 }
 

--- a/edweiss-app/model/lectures/lectureDoc.ts
+++ b/edweiss-app/model/lectures/lectureDoc.ts
@@ -19,7 +19,7 @@ import { Timestamp } from '../time';
 namespace LectureDisplay {
 
 
-	export type LectureEvents = "quiz" | "question" | "invalid";
+	export type LectureEvent = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type QuestionID = string & {};
 	export type TranscriptLangMode = 'original' | AvailableLangs;
@@ -29,13 +29,15 @@ namespace LectureDisplay {
 	};
 
 	export interface LectureEventBase {
-		type: LectureEvents;
+		type: LectureEvent;
 		done: boolean;
 		id: string;
+		pageNumber: number;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
+		pageNumber: number;
 		quizModel: LectureQuizzes.LectureQuiz;
 	}
 

--- a/edweiss-app/model/lectures/lectureDoc.ts
+++ b/edweiss-app/model/lectures/lectureDoc.ts
@@ -26,7 +26,7 @@ namespace LectureDisplay {
 		[langNumber: number]: string;
 	};
 
-	interface LectureEventBase {
+	export interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
 		id: string;

--- a/edweiss-firebase/functions/src/functions/action/createLectureQuiz.ts
+++ b/edweiss-firebase/functions/src/functions/action/createLectureQuiz.ts
@@ -18,7 +18,7 @@ export const createLectureQuiz = onSanitizedCall(Quizzes.Functions.createLecture
 		return fail("not_authorized");
 	}
 
-	const assignmentCollection = CollectionOf<LectureDisplay.LectureEvent>("courses/" + args.courseId + "/lectures/" + args.lectureId + "/lectureEvents");
+	const assignmentCollection = CollectionOf<LectureDisplay.QuizLectureEvent>("courses/" + args.courseId + "/lectures/" + args.lectureId + "/lectureEvents");
 
 	try {
 		const res = await assignmentCollection.add(args.lectureQuiz);

--- a/edweiss-firebase/functions/src/functions/lectures/broadcastQuestion.ts
+++ b/edweiss-firebase/functions/src/functions/lectures/broadcastQuestion.ts
@@ -1,0 +1,48 @@
+/**
+ * @file broadcastQuestion.ts
+ * @description Cloud function for adding question as current lecture event 
+ * @author Adamm Alaoui
+ */
+
+// ------------------------------------------------------------
+// --------------- Import Modules & Components ----------------
+// ------------------------------------------------------------
+
+import LectureDisplay from 'model/lectures/lectureDoc';
+import { onAuthentifiedCall } from 'utils/firebase';
+import { CollectionOf, getDocumentAndRef } from 'utils/firestore';
+import { fail, ok } from 'utils/status';
+
+
+// Types
+type Lecture = LectureDisplay.Lecture;
+
+// ------------------------------------------------------------
+// -----------   Broadcast Question Cloud Function    ---------
+// ------------------------------------------------------------
+
+export const broadcastQuestion = onAuthentifiedCall(LectureDisplay.Functions.broadcastQuestion, async (userId, args) => {
+    if (!args.courseId || !args.lectureId || !args.id) {
+        return fail('invalid_arg');
+    }
+
+    const [lecture, lectureRef] = await getDocumentAndRef(CollectionOf<Lecture>(`courses/${args.courseId}/lectures`), args.lectureId);
+
+    if (lecture == undefined)
+        return fail("error_firebase");
+
+
+    try {
+        await lectureRef.update({
+            ["event"]: {
+                id: args.id,
+                type: "question",
+            }
+        });
+    } catch (error) {
+        return fail('error_firebase');
+    }
+
+
+    return ok({ id: args.id });
+});

--- a/edweiss-firebase/functions/src/functions/lectures/clearQuestionEvent.ts
+++ b/edweiss-firebase/functions/src/functions/lectures/clearQuestionEvent.ts
@@ -1,0 +1,48 @@
+/**
+ * @file clearQuestionEvents.ts
+ * @description Cloud function for removing the current question lecture event 
+ * @author Adamm Alaoui
+ */
+
+// ------------------------------------------------------------
+// --------------- Import Modules & Components ----------------
+// ------------------------------------------------------------
+
+import LectureDisplay from 'model/lectures/lectureDoc';
+import { onAuthentifiedCall } from 'utils/firebase';
+import { CollectionOf, getDocumentAndRef } from 'utils/firestore';
+import { fail, ok } from 'utils/status';
+
+
+// Types
+type Lecture = LectureDisplay.Lecture;
+
+// ------------------------------------------------------------
+// -----------     Clear Question Cloud Function      ---------
+// ------------------------------------------------------------
+
+export const clearQuestionEvent = onAuthentifiedCall(LectureDisplay.Functions.clearQuestionEvent, async (userId, args) => {
+    if (!args.courseId || !args.lectureId) {
+        return fail('invalid_arg');
+    }
+
+    const [lecture, lectureRef] = await getDocumentAndRef(CollectionOf<Lecture>(`courses/${args.courseId}/lectures`), args.lectureId);
+
+    if (lecture == undefined)
+        return fail("error_firebase");
+
+
+    try {
+        await lectureRef.update({
+            ["event"]: {
+                id: "",
+                type: "invalid",
+            }
+        });
+    } catch (error) {
+        return fail('error_firebase');
+    }
+
+
+    return ok({ id: args.id });
+});

--- a/edweiss-firebase/functions/src/functions/lectures/createQuestion.ts
+++ b/edweiss-firebase/functions/src/functions/lectures/createQuestion.ts
@@ -23,7 +23,8 @@ export const createQuestion = onAuthentifiedCall(LectureDisplay.Functions.create
         username: user.name,
         anonym: args.anonym,
         likes: 0,
-        postedTime: Timestamp.now()
+        postedTime: Timestamp.now(),
+        answered: false,
     }
     const ref = await addDocument(CollectionOf<LectureDisplay.Question>(`courses/${args.courseId}/lectures/${args.lectureId}/questions`), newQuestion);
 

--- a/edweiss-firebase/functions/src/functions/lectures/markQuestionAsAnswered.ts
+++ b/edweiss-firebase/functions/src/functions/lectures/markQuestionAsAnswered.ts
@@ -1,0 +1,31 @@
+import LectureDisplay from 'model/lectures/lectureDoc';
+import { onAuthentifiedCall } from 'utils/firebase';
+import { clean, CollectionOf, getDocumentAndRef } from 'utils/firestore';
+import { fail, ok } from 'utils/status';
+
+export const markQuestionAsAnswered = onAuthentifiedCall(LectureDisplay.Functions.markQuestionAsAnswered, async (userId, args) => {
+    if (!args.id || args.id.length == 0)
+        return fail("invalid_id");
+
+    const [question, ref] = await getDocumentAndRef(CollectionOf<LectureDisplay.Question>(`courses/${args.courseId}/lectures/${args.lectureId}/questions`), args.id);
+
+    if (question == undefined)
+        return fail("error_firebase");
+
+    const updatedQuestion: Partial<LectureDisplay.Question> = {
+        anonym: question.anonym,
+        likes: question.likes,
+        postedTime: question.postedTime,
+        text: question.text,
+        userID: question.userID,
+        username: question.username,
+        answered: args.answered,
+    };
+    try {
+        await ref.update(clean(updatedQuestion))
+    } catch (error) {
+        return fail('error_firebase');
+    }
+
+    return ok({ id: ref.id });
+});

--- a/edweiss-firebase/functions/src/functions/lectures/markQuestionAsAnswered.ts
+++ b/edweiss-firebase/functions/src/functions/lectures/markQuestionAsAnswered.ts
@@ -1,7 +1,21 @@
+/**
+ * @file markQuestionAsAnswered.ts
+ * @description Cloud function for marking a question as answered
+ * @author Adamm Alaoui
+ */
+
+// ------------------------------------------------------------
+// --------------- Import Modules & Components ----------------
+// ------------------------------------------------------------
+
 import LectureDisplay from 'model/lectures/lectureDoc';
 import { onAuthentifiedCall } from 'utils/firebase';
 import { clean, CollectionOf, getDocumentAndRef } from 'utils/firestore';
 import { fail, ok } from 'utils/status';
+
+// ------------------------------------------------------------
+// ---------   Mark Question Answered Cloud Function   --------
+// ------------------------------------------------------------
 
 export const markQuestionAsAnswered = onAuthentifiedCall(LectureDisplay.Functions.markQuestionAsAnswered, async (userId, args) => {
     if (!args.id || args.id.length == 0)

--- a/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
+++ b/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz";
+	export type LectureEvents = "quiz" | "question";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -29,12 +29,16 @@ namespace LectureDisplay {
 	interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
-		pageNumber: number;
+		id: string;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
 		quizModel: Quizzes.Quiz;
+	}
+
+	export interface QuestionLectureEvent extends LectureEventBase {
+		type: "question";
 	}
 
 	export interface Question {
@@ -44,6 +48,7 @@ namespace LectureDisplay {
 		anonym: boolean,
 		likes: number,
 		postedTime: Timestamp,
+		answered: boolean,
 	}
 
 	export interface Lecture {
@@ -51,12 +56,15 @@ namespace LectureDisplay {
 		nbOfPages: number;
 		availableToStudents: boolean;
 		audioTranscript: { [pageNumber: number]: MultiLangTranscript; };
+		event?: LectureEventBase;
 	}
 
 	export const Functions = FunctionFolder("lectures", {
 		addAudioTranscript: FunctionOf<{ courseId: string, lectureId: string, pageNumber: number, transcription: string; }, {}, 'invalid_arg' | 'error_firebase' | 'successfully_added'>("addAudioTranscript"),
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
+		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
 	});
 }
 

--- a/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
+++ b/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz" | "question";
+	export type LectureEvents = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -64,7 +64,8 @@ namespace LectureDisplay {
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
 		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
-		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("broadcastQuestion"),
+		clearQuestionEvent: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("clearQuestionEvent"),
 	});
 }
 

--- a/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
+++ b/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
@@ -19,7 +19,7 @@ import { Timestamp } from '../time';
 namespace LectureDisplay {
 
 
-	export type LectureEvents = "quiz" | "question" | "invalid";
+	export type LectureEvent = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type QuestionID = string & {};
 	export type TranscriptLangMode = 'original' | AvailableLangs;
@@ -29,13 +29,15 @@ namespace LectureDisplay {
 	};
 
 	export interface LectureEventBase {
-		type: LectureEvents;
+		type: LectureEvent;
 		done: boolean;
 		id: string;
+		pageNumber: number;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
+		pageNumber: number;
 		quizModel: LectureQuizzes.LectureQuiz;
 	}
 

--- a/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
+++ b/edweiss-firebase/functions/src/model/lectures/lectureDoc.ts
@@ -26,7 +26,7 @@ namespace LectureDisplay {
 		[langNumber: number]: string;
 	};
 
-	interface LectureEventBase {
+	export interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
 		id: string;

--- a/edweiss-firebase/functions/src/utils/custom-sanitizer/quiz.ts
+++ b/edweiss-firebase/functions/src/utils/custom-sanitizer/quiz.ts
@@ -124,7 +124,8 @@ export namespace CustomPredicateQuiz {
 			done: Predicate.isBoolean,
 			pageNumber: Predicate.isPositive,
 			type: Predicate.is("quiz"),
-			quizModel: CustomPredicateQuiz.isValidLectureQuiz
+			quizModel: CustomPredicateQuiz.isValidLectureQuiz,
+			id: Predicate.isString,
 		})
 
 }

--- a/edweiss-web/src/model/lectures/lectureDoc.ts
+++ b/edweiss-web/src/model/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz";
+	export type LectureEvents = "quiz" | "question";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -29,12 +29,16 @@ namespace LectureDisplay {
 	interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
-		pageNumber: number;
+		id: string;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
 		quizModel: Quizzes.Quiz;
+	}
+
+	export interface QuestionLectureEvent extends LectureEventBase {
+		type: "question";
 	}
 
 	export interface Question {
@@ -44,6 +48,7 @@ namespace LectureDisplay {
 		anonym: boolean,
 		likes: number,
 		postedTime: Timestamp,
+		answered: boolean,
 	}
 
 	export interface Lecture {
@@ -51,12 +56,15 @@ namespace LectureDisplay {
 		nbOfPages: number;
 		availableToStudents: boolean;
 		audioTranscript: { [pageNumber: number]: MultiLangTranscript; };
+		event?: LectureEventBase;
 	}
 
 	export const Functions = FunctionFolder("lectures", {
 		addAudioTranscript: FunctionOf<{ courseId: string, lectureId: string, pageNumber: number, transcription: string; }, {}, 'invalid_arg' | 'error_firebase' | 'successfully_added'>("addAudioTranscript"),
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
+		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
 	});
 }
 

--- a/edweiss-web/src/model/lectures/lectureDoc.ts
+++ b/edweiss-web/src/model/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz" | "question";
+	export type LectureEvents = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -64,7 +64,8 @@ namespace LectureDisplay {
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
 		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
-		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("broadcastQuestion"),
+		clearQuestionEvent: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("clearQuestionEvent"),
 	});
 }
 

--- a/edweiss-web/src/model/lectures/lectureDoc.ts
+++ b/edweiss-web/src/model/lectures/lectureDoc.ts
@@ -19,7 +19,7 @@ import { Timestamp } from '../time';
 namespace LectureDisplay {
 
 
-	export type LectureEvents = "quiz" | "question" | "invalid";
+	export type LectureEvent = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type QuestionID = string & {};
 	export type TranscriptLangMode = 'original' | AvailableLangs;
@@ -29,13 +29,15 @@ namespace LectureDisplay {
 	};
 
 	export interface LectureEventBase {
-		type: LectureEvents;
+		type: LectureEvent;
 		done: boolean;
 		id: string;
+		pageNumber: number;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
+		pageNumber: number;
 		quizModel: LectureQuizzes.LectureQuiz;
 	}
 

--- a/edweiss-web/src/model/lectures/lectureDoc.ts
+++ b/edweiss-web/src/model/lectures/lectureDoc.ts
@@ -26,7 +26,7 @@ namespace LectureDisplay {
 		[langNumber: number]: string;
 	};
 
-	interface LectureEventBase {
+	export interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
 		id: string;

--- a/model/src/lectures/lectureDoc.ts
+++ b/model/src/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz";
+	export type LectureEvents = "quiz" | "question";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -29,12 +29,16 @@ namespace LectureDisplay {
 	interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
-		pageNumber: number;
+		id: string;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
 		quizModel: Quizzes.Quiz;
+	}
+
+	export interface QuestionLectureEvent extends LectureEventBase {
+		type: "question";
 	}
 
 	export interface Question {
@@ -44,6 +48,7 @@ namespace LectureDisplay {
 		anonym: boolean,
 		likes: number,
 		postedTime: Timestamp,
+		answered: boolean,
 	}
 
 	export interface Lecture {
@@ -51,12 +56,15 @@ namespace LectureDisplay {
 		nbOfPages: number;
 		availableToStudents: boolean;
 		audioTranscript: { [pageNumber: number]: MultiLangTranscript; };
+		event?: LectureEventBase;
 	}
 
 	export const Functions = FunctionFolder("lectures", {
 		addAudioTranscript: FunctionOf<{ courseId: string, lectureId: string, pageNumber: number, transcription: string; }, {}, 'invalid_arg' | 'error_firebase' | 'successfully_added'>("addAudioTranscript"),
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
+		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
 	});
 }
 

--- a/model/src/lectures/lectureDoc.ts
+++ b/model/src/lectures/lectureDoc.ts
@@ -18,7 +18,7 @@ import { Timestamp } from '../time';
 
 namespace LectureDisplay {
 
-	export type LectureEvents = "quiz" | "question";
+	export type LectureEvents = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type TranscriptLangMode = 'original' | AvailableLangs;
 
@@ -64,7 +64,8 @@ namespace LectureDisplay {
 		createQuestion: FunctionOf<{ courseId: string, lectureId: string, question: string, anonym: boolean; }, { id: string; }, 'invalid_arg' | 'error_firebase' | 'empty_question' | 'user_not_found' | 'not_in_course'>("createQuestion"),
 		likeQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string, likes: number; }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("likeQuestion"),
 		markQuestionAsAnswered: FunctionOf<{ id: string, courseId: string, lectureId: string, answered: boolean }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
-		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("markQuestionAsAnswered"),
+		broadcastQuestion: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("broadcastQuestion"),
+		clearQuestionEvent: FunctionOf<{ id: string, courseId: string, lectureId: string }, { id: string; }, 'invalid_id' | 'error_firebase' | 'empty_question'>("clearQuestionEvent"),
 	});
 }
 

--- a/model/src/lectures/lectureDoc.ts
+++ b/model/src/lectures/lectureDoc.ts
@@ -19,7 +19,7 @@ import { Timestamp } from '../time';
 namespace LectureDisplay {
 
 
-	export type LectureEvents = "quiz" | "question" | "invalid";
+	export type LectureEvent = "quiz" | "question" | "invalid";
 	export type AvailableLangs = "english" | "french" | "spanish" | "italian" | "german" | "brazilian" | "arabic" | "chinese" | "vietanames" | "hindi";
 	export type QuestionID = string & {};
 	export type TranscriptLangMode = 'original' | AvailableLangs;
@@ -29,13 +29,15 @@ namespace LectureDisplay {
 	};
 
 	export interface LectureEventBase {
-		type: LectureEvents;
+		type: LectureEvent;
 		done: boolean;
 		id: string;
+		pageNumber: number;
 	}
 
 	export interface QuizLectureEvent extends LectureEventBase {
 		type: "quiz";
+		pageNumber: number;
 		quizModel: LectureQuizzes.LectureQuiz;
 	}
 

--- a/model/src/lectures/lectureDoc.ts
+++ b/model/src/lectures/lectureDoc.ts
@@ -26,7 +26,7 @@ namespace LectureDisplay {
 		[langNumber: number]: string;
 	};
 
-	interface LectureEventBase {
+	export interface LectureEventBase {
 		type: LectureEvents;
 		done: boolean;
 		id: string;


### PR DESCRIPTION
**Description**
This pull request outlines the progress made into providing the broadcast live student question from the teacher's ShowTime! Remote Control, to the ShowTime whiteboard. This way the student can follow other's people questions and benefit from the lecturer answer, ans also the lecturer can have an easier look at the live question that student may have asked long time ago. To this extent,  I have adapt the `lectureDoc` model to be able to support this broadcasting feature. Further more, as the question broadcasting is in the STRC, we have tried to keep the UI/UX as close of the one expected from a remote control. Moreover, work has been made into keeping the coverage as high as possible and cover new code region. (Note: look at the coverage section where I discuss sonar cloud complains)

**Feature Checklist**
- Connect the `questionToSlide` to the STRC
- Provide the question display in the STRC and broadcasting cloud functions
- Adapt the ShowTime content display, to display the broadcasted question
- Update/Create test suites for modified/created componenent 

**Coverage**
| File Name   | Coverage   | Line Miss | Comment     |
|----------------|:-----------------:|:-------------------:|---------------------------------|
| `index.tsx` | 84.12 |90-91,138-142,287 | This lines are respectively due to the landscape setting, pdf arguments, and the modal instantiation |
| `abstractRmtCtl.tsx` | 94.73 | 237-238 | This lines are the modals instantiation |
| `lecture/remotecontrol/modal.tsx` | 97.22 | 467,482 | Some console.log on try-catch error|
| `questionToSlide.tsx` | 96.77 | 148 | The modal instantiation |

Side Note: All sonar cloud complains are related to files that were not added/modified in this PR. As you can see in the git history I have patch all of mine. It complains about the line coverage and also the issue as the following image highlights

![Sonar-conmplains](https://github.com/user-attachments/assets/e9ccb62b-1b69-4a42-b48a-5d5468362f7e)
:

**Depandancies**
- `react-native`  [Vibration](https://reactnative.dev/docs/vibration)
- `@react-native-voice/voice` version [3.2.4](https://www.npmjs.com/package/@react-native-voice/voice/v/3.2.4)
- `openai` API credential for GPT-4o mini. (It's a `.env` file that should be placed in `edweiss-firebase/functions` and `gitignore`-d )

**How to run it**
- Go to the `community` page and click on the `Go to STRC` button.
- Then select click on the chat icon
- Then, press on one live question and click on `Broadcast Question` on the appearing modal
- Go to `ShowTime` to check that the question is currently broadcasted
- Then go back to the `STRC` in the question tab. Then re-press on the current question and click on `Mark Answered`
- Then go back to `ShowTime` to check that the PDF is now displaying back again 

**Demo**

Question Broacast stress test - live 🔴
--

https://github.com/user-attachments/assets/5e0c0d8e-1f82-445f-9435-536704d51476


Nothing to display
--
![no-question](https://github.com/user-attachments/assets/bc712e57-0814-4a02-9d54-d6c8d5a7e62d)


Rotation Handling
--
- Landscape
![landscape-question](https://github.com/user-attachments/assets/f728f73a-1728-4187-844f-a039063d23af)

- Portrait
![portrait-question](https://github.com/user-attachments/assets/c376841b-d4c2-41ef-8374-0ed28d5a601e)


Question Management Modal
--
![broadcast-modal](https://github.com/user-attachments/assets/4d3d9cce-119c-4771-92bc-435b08fd6fae)

![answered-modal](https://github.com/user-attachments/assets/d22b55b3-6667-440e-a29b-dcdcaca0a2eb)

