### PR TITLE
Fix/student question UI

### DIFF
--- a/edweiss-app/__test__/showtime/LectureScreen.test.tsx
+++ b/edweiss-app/__test__/showtime/LectureScreen.test.tsx
@@ -355,12 +355,6 @@ describe('LectureScreen Component', () => {
         await waitFor(() => expect(console.error).toHaveBeenCalledWith('Error loading PDF URL:', expect.any(Error)));
     });
 
-    it('displays default transcript text if audio transcript is missing', () => {
-        // Checks that the default transcript text is displayed when no transcript data is available
-        render(<LectureScreen />);
-        expect(screen.getByText('showtime:lecturer_transcript_deftxt')).toBeTruthy();
-    });
-
     it('allows navigation to the next PDF page', async () => {
         // Ensures the "next page" navigation button for the PDF works correctly
         render(<LectureScreen />);

--- a/edweiss-app/app/(app)/lectures/slides/index.tsx
+++ b/edweiss-app/app/(app)/lectures/slides/index.tsx
@@ -66,8 +66,8 @@ const LectureScreen: ApplicationRoute = () => {
     // UI display setting's hooks
     const [isLandscape, setIsLandscape] = useState<boolean>(false);       // Landscape display boolean for different UI
     const [isFullscreen, setIsFullscreen] = useState<boolean>(false);    // FullScreen display of pdf toggle
-    const colorScheme = useTheme();    // Get the current color scheme (light or dark)
     const [transMode, setTransMode] = useState<TranscriptLangMode>('original');          // Current transcript mode 
+    const colorScheme = useTheme();    // Get the current color scheme (light or dark)
 
     const [lectureDoc] = usePrefetchedDynamicDoc(CollectionOf<Lecture>(`courses/${courseName}/lectures`), lectureId, undefined);
     const questionsDoc = useDynamicDocs(CollectionOf<Question>(`courses/${courseName}/lectures/${lectureId}/questions`));
@@ -225,7 +225,7 @@ const LectureScreen: ApplicationRoute = () => {
             {isFullscreen ?
 
                 <TView mr={'lg'} flexDirection='column' style={{ width: '100%', height: '100%', position: 'relative' }} >
-                    {LectureViewer({ uri, widthPorp: 1, heightProp: 1, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape })}
+                    {LectureViewer({ uri, widthPorp: 1, heightProp: 1, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape, colorScheme })}
                     {ControlButtons()}
                 </TView>
 
@@ -233,7 +233,7 @@ const LectureScreen: ApplicationRoute = () => {
                 : isLandscape ?
                     <TView flexDirection={'row'} flex={1} style={{ width: '100%' }}>
                         <TView flexDirection='column' style={{ width: '60%', height: '100%', position: 'relative' }} >
-                            {LectureViewer({ uri, widthPorp: 0.6, heightProp: 1, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape })}
+                            {LectureViewer({ uri, widthPorp: 0.6, heightProp: 1, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape, colorScheme })}
                             {ControlButtons()}
                         </TView>
                         {ContentView('40%', '100%')}
@@ -243,7 +243,7 @@ const LectureScreen: ApplicationRoute = () => {
                     :
                     <TView flexDirection={'column'} flex={1} style={{ width: '100%' }}>
                         <TView flexDirection='column' style={{ width: '100%', height: '40%', position: 'relative' }} >
-                            {LectureViewer({ uri, widthPorp: 1, heightProp: 0.6, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape })}
+                            {LectureViewer({ uri, widthPorp: 1, heightProp: 0.6, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape, colorScheme })}
                             {ControlButtons()}
                         </TView>
                         {ContentView('100%', '60%')}
@@ -276,7 +276,8 @@ const LectureViewer: React.FC<{
     setCurrentPage: (currentPage: number) => void;
     page: number;
     isLandscape: boolean;
-}> = ({ uri, widthPorp, heightProp, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape }) => {
+    colorScheme: string;
+}> = ({ uri, widthPorp, heightProp, currentEvent, currentQuestion, setNumPages, setCurrentPage, page, isLandscape, colorScheme }) => {
 
     return (currentEvent && currentEvent.type === "invalid") ? (
         <Pdf
@@ -291,6 +292,7 @@ const LectureViewer: React.FC<{
             horizontal
             style={{
                 flex: 1,
+                backgroundColor: colorScheme == "dark" ? "#181825" : "#e6e9ef",
                 width: Dimensions.get('window').width * widthPorp,
                 height: Dimensions.get('window').height * heightProp,
             }}

--- a/edweiss-app/components/lectures/slides/StudentQuestion.tsx
+++ b/edweiss-app/components/lectures/slides/StudentQuestion.tsx
@@ -56,7 +56,7 @@ const StudentQuestion: ReactComponent<{ courseName: string, lectureId: string, q
         question: Document<LectureDisplay.Question>;
         index: number;
     }> = ({ question, index }) => {
-        const { text, anonym, userID, likes, username, postedTime } = question.data;
+        const { text, anonym, userID, likes, username, postedTime, answered } = question.data;
         const isUser = uid == userID;
         const id = question.id;
         const likedStorageKey = `stquestion-${id}`;
@@ -82,11 +82,14 @@ const StudentQuestion: ReactComponent<{ courseName: string, lectureId: string, q
 
         return (
             <>
-                <TView key={index} mb={'sm'} backgroundColor={isUser ? 'overlay0' : 'crust'} borderColor='surface0' radius={'lg'} flex={1} flexDirection='column' ml='md' style={{ right: isUser ? 0 : 10 }}>
-                    <TView borderColor={isUser ? 'crust' : 'overlay0'} bb={1} flexDirection='row' flexColumnGap={10} alignItems='center' radius={'lg'} mb={'sm'}>
-                        <Avatar size={40} name={anonym ? undefined : username} uid={anonym ? undefined : userID} />
-                        <TView flex={1}>
-                            <TText ml={16} mb={4} size={'sm'} pl={2} pt={'sm'}>{anonym ? "Anonymous" : username}, {Time.agoTimestamp(postedTime)}</TText>
+                {!answered && <TView key={index} mb={'sm'} backgroundColor='crust' borderColor='surface0' radius={'lg'} flex={1} flexDirection='column' mr={isUser ? 'md' : 'lg'} ml={isUser ? 'lg' : 'md'} style={{ right: isUser ? 0 : 10 }}>
+                    <TView pt={'sm'} flexDirection='row' flexColumnGap={10} alignItems='center' radius={'lg'} mb={'sm'}>
+                        <TView ml={'md'}>
+                            <Avatar size={30} name={anonym ? undefined : username} uid={anonym ? undefined : userID} />
+                        </TView>
+                        <TView flex={1} flexDirection='row' alignItems='flex-end' justifyContent='space-between'>
+                            <TText mb={4} size={'sm'} pl={2} pt={'sm'}>{anonym ? "Anonymous" : username}</TText>
+                            <TText size={'xs'}>{Time.agoTimestamp(postedTime)}</TText>
                         </TView>
                     </TView>
                     <TText pl={'md'}>
@@ -97,7 +100,7 @@ const StudentQuestion: ReactComponent<{ courseName: string, lectureId: string, q
                         <Icon name={liked ? 'heart' : 'heart-outline'} color='red' size={24} />
                         <TText color='red' size={'xs'} bold lineHeight={14}>{likeCount}</TText>
                     </TTouchableOpacity>
-                </TView>
+                </TView>}
             </>
 
         );

--- a/edweiss-app/components/lectures/slides/StudentQuestion.tsx
+++ b/edweiss-app/components/lectures/slides/StudentQuestion.tsx
@@ -88,7 +88,7 @@ const StudentQuestion: ReactComponent<{ courseName: string, lectureId: string, q
                             <Avatar size={30} name={anonym ? undefined : username} uid={anonym ? undefined : userID} />
                         </TView>
                         <TView flex={1} flexDirection='row' alignItems='flex-end' justifyContent='space-between'>
-                            <TText mb={4} size={'sm'} pl={2} pt={'sm'}>{anonym ? "Anonymous" : username}</TText>
+                            <TText mb={'xs'} size={'sm'} pl={2} pt={'sm'}>{anonym ? "Anonymous" : username}</TText>
                             <TText size={'xs'}>{Time.agoTimestamp(postedTime)}</TText>
                         </TView>
                     </TView>


### PR DESCRIPTION
This is a small PR that changes a bit of the format and UI of the StudentQuestion display in the LectureScreen after receiving some recommendations of changes. 

- There is no longer a color difference for the user message when the message is your own
- Removed the line separating user info and text
- Reduced the Avatar size
- made the username closer to the avatar
- Some paddings were improved
- Placed timestamp for time created to the right 
- Increased the difference in padding for user messages that are your own messages and those that are not to better differenciate without the need of color change
- Questions are no longer displayed after being answered by the professor
- Fixed unnoticed merge conflict error, where the background color change of the PDF was no longer present depending on the colorScheme of the Screen

There was no major change in functionalities so the tests continue with the same coverage

![image](https://github.com/user-attachments/assets/dc855fc4-fb48-4614-8c20-26954cd20f26)
![image](https://github.com/user-attachments/assets/edf9e559-38a9-4667-a38e-81a7722706c6)
